### PR TITLE
update config templates to D13

### DIFF
--- a/templates/partGun_GSD_template.py
+++ b/templates/partGun_GSD_template.py
@@ -7,7 +7,7 @@ import FWCore.ParameterSet.Config as cms
 
 from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process('HLT',eras.Phase2C2_timing)
+process = cms.Process('HLT',eras.Phase2C2)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')
@@ -15,8 +15,8 @@ process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
 process.load('FWCore.MessageService.MessageLogger_cfi')
 process.load('Configuration.EventContent.EventContent_cff')
 process.load('SimGeneral.MixingModule.DUMMYPU')
-process.load('Configuration.Geometry.GeometryExtended2023D4Reco_cff')
-process.load('Configuration.Geometry.GeometryExtended2023D4_cff')
+process.load('Configuration.Geometry.GeometryExtended2023D13Reco_cff')
+process.load('Configuration.Geometry.GeometryExtended2023D13_cff')
 process.load('Configuration.StandardSequences.MagneticField_cff')
 process.load('Configuration.StandardSequences.Generator_cff')
 process.load('Configuration.StandardSequences.VtxSmearedNoSmear_cff')

--- a/templates/partGun_NTUP_template.py
+++ b/templates/partGun_NTUP_template.py
@@ -12,6 +12,9 @@ process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 process.load('RecoLocalCalo.HGCalRecProducers.HGCalLocalRecoSequence_cff')
 #process.load("RecoLocalCalo.HGCalRecProducers.hgcalLayerClusters_cfi")
 
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic', '')
+
 from FastSimulation.Event.ParticleFilter_cfi import *
 
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(DUMMYEVTSPERJOB) )

--- a/templates/partGun_NTUP_template.py
+++ b/templates/partGun_NTUP_template.py
@@ -4,8 +4,8 @@ from Configuration.StandardSequences.Eras import eras
 process = cms.Process("Demo")
 process.load('Configuration.StandardSequences.Services_cff')
 process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
-process.load('Configuration.Geometry.GeometryExtended2023D4Reco_cff')
-process.load('Configuration.StandardSequences.MagneticField_38T_PostLS1_cff')
+process.load('Configuration.Geometry.GeometryExtended2023D13Reco_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
 process.load('Configuration.EventContent.EventContent_cff')
 process.load("FWCore.MessageService.MessageLogger_cfi")
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
@@ -21,11 +21,11 @@ process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring(
         DUMMYINPUTFILELIST
     ),
-    duplicateCheckMode = cms.untracked.string("noDuplicateCheck"),
-    inputCommands=cms.untracked.vstring(
-        'keep *',
-        'drop EcalEBTriggerPrimitiveDigisSorted_simEcalEBTriggerPrimitiveDigis__HLT'
-    )
+    duplicateCheckMode = cms.untracked.string("noDuplicateCheck")
+    # inputCommands=cms.untracked.vstring(
+    #     'keep *',
+    #     'drop EcalEBTriggerPrimitiveDigisSorted_simEcalEBTriggerPrimitiveDigis__HLT'
+    # )
 )
 
 process.ana = cms.EDAnalyzer('HGCalAnalysis',
@@ -33,7 +33,7 @@ process.ana = cms.EDAnalyzer('HGCalAnalysis',
                              rawRecHits = cms.bool(True),
                              readOfficialReco = cms.bool(DUMMYROR),
                              readCaloParticles = cms.bool(False),
-                             layerClusterPtThreshold = cms.double(0.01),  # All LayerCluster belonging to a multicluster are saved; this Pt threshold applied to the others
+                             layerClusterPtThreshold = cms.double(-1),  # All LayerCluster belonging to a multicluster are saved; this Pt threshold applied to the others
                              TestParticleFilter = ParticleFilterBlock.ParticleFilter
 )
 
@@ -46,15 +46,15 @@ process.TFileService = cms.Service("TFileService",
 
                                    )
 
-reRunClustering = False
+reRunClustering = True
 
 if reRunClustering:
-    process.hgcalLayerClusters.minClusters = cms.uint32(0)
-    process.hgcalLayerClusters.realSpaceCone = cms.bool(True)
-    process.hgcalLayerClusters.multiclusterRadius = cms.double(2.)  # in cm if realSpaceCone is true
-    process.hgcalLayerClusters.dependSensor = cms.bool(True)
-    process.hgcalLayerClusters.ecut = cms.double(3.)  # multiple of sigma noise if dependSensor is true
-    process.hgcalLayerClusters.kappa = cms.double(9.)  # multiple of sigma noise if dependSensor is true
+    # process.hgcalLayerClusters.minClusters = cms.uint32(0)
+    # process.hgcalLayerClusters.realSpaceCone = cms.bool(True)
+    # process.hgcalLayerClusters.multiclusterRadius = cms.double(2.)  # in cm if realSpaceCone is true
+    # process.hgcalLayerClusters.dependSensor = cms.bool(True)
+    # process.hgcalLayerClusters.ecut = cms.double(3.)  # multiple of sigma noise if dependSensor is true
+    # process.hgcalLayerClusters.kappa = cms.double(9.)  # multiple of sigma noise if dependSensor is true
     #process.hgcalLayerClusters.deltac = cms.vdouble(2.,3.,5.) #specify delta c for each subdetector separately
     process.p = cms.Path(process.hgcalLayerClusters+process.ana)
 else:

--- a/templates/partGun_RECO_template.py
+++ b/templates/partGun_RECO_template.py
@@ -7,7 +7,7 @@ import FWCore.ParameterSet.Config as cms
 
 from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process('RECO',eras.Phase2C2_timing)
+process = cms.Process('RECO',eras.Phase2C2)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')
@@ -15,7 +15,7 @@ process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
 process.load('FWCore.MessageService.MessageLogger_cfi')
 process.load('Configuration.EventContent.EventContent_cff')
 process.load('SimGeneral.MixingModule.mixNoPU_cfi')
-process.load('Configuration.Geometry.GeometryExtended2023D4Reco_cff')
+process.load('Configuration.Geometry.GeometryExtended2023D13Reco_cff')
 process.load('Configuration.StandardSequences.MagneticField_cff')
 process.load('Configuration.StandardSequences.RawToDigi_cff')
 process.load('Configuration.StandardSequences.L1Reco_cff')


### PR DESCRIPTION
There are some important changes in this PR:

1. the `layerClusterPtThreshold` for the ntupliser is set to -1 to dump all layer clusters to the ntuple
1. clustering is rerun by default when running the ntupliser (using default settings) - it probably makes sense to have a flag for that later (volunteers?)
1. the geometry is updated to _D13_, which corresponds to v8 of HGCal

The latter change is needed to be able to run on the corresponding RelVals. Mind that using inconsistent geometries will lead to wrong results, i.e. re-running the clustering on a sample that has been produced with D4 will work, but will give wrong clusters and RecHits etc. 