### PR TITLE
Add option to use pythia8 particle gun

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,11 @@ To produce `NEVENTS` GEN-SIM-DIGI events with `NPART` sets of particles (per eve
   --thresholdMin PTMIN
   --thresholdMax PTMAX
   --gunType GUNTYPE
+  [--gunMode GUNMODE]
   [--local]
   --tag MYTAG
 ```
-Here, one can produce a custom set of particles by providing `PART_PDGID` as a set of comma-separated single PDG IDs.
+Here, one can produce a custom set of particles by providing `PART_PDGID` as a set of comma-separated single PDG IDs. To simulate the decay of unstable particles, e.g. quarks, gluons or taus,  an alternative particle gun based on PYTHIA8 can be used by setting `--gunMode pythia8`. 
 
 To produce `NEVENTS` GEN-SIM-DIGI events with pair of particles within given angular distance ΔR(η,φ) (per event), where the first particle is of type `PART_PDGID` and in the p_T range from `PTMIN` to `PTMAX`, and the second one is of type `INCONE_PART_PDGID` and at distance from `DRMIN` to `DRMAX` and with p_T in range from `PTRATIO_MIN` to `PTRATIO_MAX` relative to the first particle, one should run:
 ```
@@ -43,6 +44,7 @@ To produce `NEVENTS` GEN-SIM-DIGI events with pair of particles within given ang
   --thresholdMin PTMIN
   --thresholdMax PTMAX
   --gunType Pt
+  [--gunMode GUNMODE]
   --InConeID INCONE_PART_PDGID
   --MinDeltaR DRMIN
   --MaxDeltaR DRMAX
@@ -51,7 +53,7 @@ To produce `NEVENTS` GEN-SIM-DIGI events with pair of particles within given ang
   [--local]
   --tag MYTAG
 ```
-One should also note that for the genertion of pairs of particles within a given cone, one has to use the "Pt" gun.
+One should also note that for the genertion of pairs of particles within a given cone, one has to use the "Pt" gun. Also note that it is currently not possible to generate pairs within a cone using the PYTHIA8-based gun.
 
 The script will create a directory called `partGun_[MYTAG]_[DATE]` locally or on the CMG EOS area (see options), and submit jobs to queue `QUEUENAME` with `NPERJOB` events per job,
 `NEVENTS` in total.

--- a/SubmitHGCalPGun.py
+++ b/SubmitHGCalPGun.py
@@ -86,7 +86,7 @@ def parseOptions():
 
     # list of supported particles, check if requested partID list is a subset of the list of the supported ones
     global particles
-    particles = ['22', '111', '211', '11', '13', '15', '12', '14', '16', '130', '1', '2', '3', '4', '5']
+    particles = ['22', '111', '211', '11', '13', '15', '12', '14', '16', '130', '1', '2', '3', '4', '5', '22']
     inPartID = [p.strip(" ") for p in opt.PARTID.split(",")] # prepare list of requested IDs (split by ",", strip white spaces)
     if not (set(inPartID) < set(particles) or opt.PARTID == ''):
         parser.error('Particle(s) with ID(s) ' + opt.PARTID + ' is not supported. Exiting...')

--- a/templates/partGun_GSD_template.py
+++ b/templates/partGun_GSD_template.py
@@ -78,22 +78,42 @@ process.mix.digitizers = cms.PSet(process.theDigitizersValid)
 from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic', '')
 
-process.generator = cms.EDProducer("GUNPRODUCERTYPE",
-    AddAntiParticle = cms.bool(True),
-    PGunParameters = cms.PSet(
-        MaxEta = cms.double(3.0),
-        MaxPhi = cms.double(3.14159265359),
-        MAXTHRESHSTRING = cms.double(DUMMYTHRESHMAX),
-        MinEta = cms.double(1.479),
-        MinPhi = cms.double(-3.14159265359),
-        MINTHRESHSTRING = cms.double(DUMMYTHRESHMIN),
-        #DUMMYINCONESECTION
-        PartID = cms.vint32(DUMMYIDs)
-    ),
-    Verbosity = cms.untracked.int32(0),
-    firstRun = cms.untracked.uint32(1),
-    psethack = cms.string('multiple particles predefined pT/E eta 1p479 to 3')
-)
+gunmode = 'GUNMODE'
+
+if gunmode == 'default':
+    process.generator = cms.EDProducer("GUNPRODUCERTYPE",
+        AddAntiParticle = cms.bool(True),
+        PGunParameters = cms.PSet(
+            MaxEta = cms.double(3.0),
+            MaxPhi = cms.double(3.14159265359),
+            MAXTHRESHSTRING = cms.double(DUMMYTHRESHMAX),
+            MinEta = cms.double(1.479),
+            MinPhi = cms.double(-3.14159265359),
+            MINTHRESHSTRING = cms.double(DUMMYTHRESHMIN),
+            #DUMMYINCONESECTION
+            PartID = cms.vint32(DUMMYIDs)
+        ),
+        Verbosity = cms.untracked.int32(0),
+        firstRun = cms.untracked.uint32(1),
+        psethack = cms.string('multiple particles predefined pT/E eta 1p479 to 3')
+    )
+elif gunmode == 'pythia8':
+    process.generator = cms.EDFilter("GUNPRODUCERTYPE",
+        maxEventsToPrint = cms.untracked.int32(1),
+        pythiaPylistVerbosity = cms.untracked.int32(1),
+        pythiaHepMCVerbosity = cms.untracked.bool(True),
+        PGunParameters = cms.PSet(
+          ParticleID = cms.vint32(DUMMYIDs),
+          AddAntiParticle = cms.bool(True),
+          MinPhi = cms.double(-3.14159265359),
+          MaxPhi = cms.double(3.14159265359),
+          MINTHRESHSTRING = cms.double(DUMMYTHRESHMIN),
+          MAXTHRESHSTRING = cms.double(DUMMYTHRESHMAX),
+          MinEta = cms.double(1.479),
+          MaxEta = cms.double(3.0)
+          ),
+        PythiaParameters = cms.PSet(parameterSets = cms.vstring())
+    )
 
 # Path and EndPath definitions
 process.generation_step = cms.Path(process.pgen)


### PR DESCRIPTION
Can be used to generate quarks or gluons to produce jets. Adds option `--gunMode`
which can be set to `default` or `pythia8`. Default behaviour of SubmitHGCalPGun.py
is unchanged.