### PR TITLE
parameters to enable HGC hit time

### DIFF
--- a/templates/partGun_GSD_template.py
+++ b/templates/partGun_GSD_template.py
@@ -9,6 +9,21 @@ from Configuration.StandardSequences.Eras import eras
 
 process = cms.Process('HLT',eras.Phase2)
 
+from SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi import hgchefrontDigitizer
+hgchefrontDigitizer.tofDelay = cms.double(5.)
+hgchefrontDigitizer.digiCfg.feCfg.jitterNoise_ns = cms.vdouble(25., 25., 25.)
+hgchefrontDigitizer.digiCfg.feCfg.jitterConstant_ns = cms.vdouble(0.0004, 0.0004, 0.0004)
+hgchefrontDigitizer.digiCfg.feCfg.tdcForToAOnset_fC = cms.vdouble(12, 12, 12)
+hgchefrontDigitizer.digiCfg.feCfg.toaLSB_ns = cms.double(0.0244)
+
+from SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi import hgceeDigitizer
+hgceeDigitizer.tofDelay = cms.double(5.)
+hgceeDigitizer.digiCfg.feCfg.jitterNoise_ns = cms.vdouble(25., 25., 25.)
+hgceeDigitizer.digiCfg.feCfg.jitterConstant_ns = cms.vdouble(0.0004, 0.0004, 0.0004)
+hgceeDigitizer.digiCfg.feCfg.tdcForToAOnset_fC = cms.vdouble(12, 12, 12)
+hgceeDigitizer.digiCfg.feCfg.toaLSB_ns = cms.double(0.0244)
+
+
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')
 process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')

--- a/templates/partGun_RECO_template.py
+++ b/templates/partGun_RECO_template.py
@@ -9,6 +9,13 @@ from Configuration.StandardSequences.Eras import eras
 
 process = cms.Process('RECO',eras.Phase2)
 
+from SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi import hgchefrontDigitizer
+hgchefrontDigitizer.digiCfg.feCfg.toaLSB_ns = cms.double(0.0244)
+
+from SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi import hgceeDigitizer
+hgceeDigitizer.digiCfg.feCfg.toaLSB_ns = cms.double(0.0244)
+
+
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')
 process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')


### PR DESCRIPTION
I added in the configuration files the parameters to enable the time for hits above 12fC, and smearing as used for the performance studies in the TDR.
The settings are needed at the DIGI level and RECO step.
IMPORTANT: this solution is compatible with ≥ 941pre2, for previous release there is no backport. 