### PR TITLE
Add D28 and D30 fragment generation scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ For details on the pileup scenario, please see https://github.com/cms-sw/cmssw/b
 | [produceSkeletons_D17_NoSmear_noPU.sh](templates/python/produceSkeletons_D17_NoSmear_noPU.sh) | Phase2_timing | D17 | NoSmear | none |
 | [produceSkeletons_D17_NoSmear_PU_AVE_200_BX_25ns.sh](templates/python/produceSkeletons_D17_NoSmear_PU_AVE_200_BX_25ns.sh) | Phase2_timing | D17 | NoSmear | AVE_200_BX_25ns |
 | [produceSkeletons_D23_VtxSmearedHLLHC_noPU.sh](templates/python/produceSkeletons_D23_VtxSmearedHLLHC_noPU.sh) | Phase2 | D23 | VtxSmearedHLLHC | none |
+| [produceSkeletons_D28_VtxSmearedHLLHC_noPU.sh](templates/python/produceSkeletons_D28_VtxSmearedHLLHC_noPU.sh) | Phase2C4 | D28 | VtxSmearedHLLHC | none |
+| [produceSkeletons_D30_VtxSmearedHLLHC_noPU.sh](templates/python/produceSkeletons_D30_VtxSmearedHLLHC_noPU.sh) | Phase2C4 | D30 | VtxSmearedHLLHC | none |
 
 Whenever you would like to change configuration, change to the `reco_prodtools/templates/python` directory and execute the corresponding script. Then make sure to run `scram b`.
 

--- a/templates/python/produceSkeletons_D23_VtxSmearedHLLHC_noPU.sh
+++ b/templates/python/produceSkeletons_D23_VtxSmearedHLLHC_noPU.sh
@@ -29,7 +29,7 @@ cmsDriver.py SinglePiPt25Eta1p7_2p7_cfi  --conditions auto:phase2_realistic \
   -n 10 --era Phase2 --eventcontent FEVTDEBUGHLT --nThreads 4 \
   -s GEN,SIM,DIGI:pdigi_valid,L1,L1TrackTrigger,DIGI2RAW,HLT:@fake2 \
   --datatier GEN-SIM --beamspot HLLHC \
-  --geometry Extended2023D23 --era Phase2 \
+  --geometry Extended2023D23 \
   --no_exec --python_filename=GSD_fragment.py
 
 

--- a/templates/python/produceSkeletons_D28_VtxSmearedHLLHC_noPU.sh
+++ b/templates/python/produceSkeletons_D28_VtxSmearedHLLHC_noPU.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+
+# This is the shell script that will generate all the skeletons using cmsDriver commands.
+# The commands included have been taken from runTheMatrix with the following command:
+#
+# runTheMatrix.py -l 24034.0 --command="--no_exec" --dryRun
+#
+# For all commands remove --filein and --fileout options.
+# Add python_filename option
+#
+# The first command combines step1 and step2 (GSD):
+# - run up to DIGI...HLT:@fake2
+# The following changes are implemented on top:
+# --eventcontent FEVTDEBUG ➜ --eventcontent FEVTDEBUGHLT
+#
+# The second command is step3 removing overlap with step2 (RECO):
+# - also remove MINIAODSIM, PAT
+# - remove from VALIDATION@miniAODValidation
+# - remove from DQM:@miniAODDQM
+#
+# The third command is a copy of the second only re-running RECO (for NTUP):
+# - remove DQM
+# - add processName=NTUP option
+#
+# Those commands should be regularly checked and, in case of changes, propagated into this script!
+
+
+cmsDriver.py SinglePiPt25Eta1p7_2p7_cfi  --conditions auto:phase2_realistic \
+  -n 10 --era Phase2C4 --eventcontent FEVTDEBUGHLT --nThreads 4 \
+  -s GEN,SIM,DIGI:pdigi_valid,L1,L1TrackTrigger,DIGI2RAW,HLT:@fake2 \
+  --datatier GEN-SIM --beamspot HLLHC14TeV \
+  --geometry Extended2023D28 \
+  --no_exec --python_filename=GSD_fragment.py
+
+
+cmsDriver.py step3  --conditions auto:phase2_realistic -n 10 \
+  --era Phase2C4 --eventcontent FEVTDEBUGHLT,DQM --runUnscheduled --nThreads 4 \
+  -s RAW2DIGI,L1Reco,RECO,RECOSIM,VALIDATION:@phase2Validation,DQM:@phase2 \
+  --datatier GEN-SIM-RECO,DQMIO --geometry Extended2023D28 \
+  --no_exec --python_filename=RECO_fragment.py
+
+
+cmsDriver.py step3 --conditions auto:phase2_realistic -n 10 \
+  --era Phase2C4 --eventcontent FEVTDEBUGHLT --runUnscheduled \
+  -s RAW2DIGI,L1Reco,RECO,RECOSIM \
+  --datatier GEN-SIM-RECO --geometry Extended2023D28 \
+  --no_exec --python_filename=NTUP_fragment.py \
+  --processName=NTUP

--- a/templates/python/produceSkeletons_D30_VtxSmearedHLLHC_noPU.sh
+++ b/templates/python/produceSkeletons_D30_VtxSmearedHLLHC_noPU.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+
+# This is the shell script that will generate all the skeletons using cmsDriver commands.
+# The commands included have been taken from runTheMatrix with the following command:
+#
+# runTheMatrix.py -w upgrade -l 24834.0 --command="--no_exec" --dryRun
+#
+# For all commands remove --filein and --fileout options.
+# Add python_filename option
+#
+# The first command combines step1 and step2 (GSD):
+# - run up to DIGI...HLT:@fake2
+# The following changes are implemented on top:
+# --eventcontent FEVTDEBUG ➜ --eventcontent FEVTDEBUGHLT
+#
+# The second command is step3 removing overlap with step2 (RECO):
+# - also remove MINIAODSIM, PAT
+# - remove from VALIDATION@miniAODValidation
+# - remove from DQM:@miniAODDQM
+#
+# The third command is a copy of the second only re-running RECO (for NTUP):
+# - remove DQM
+# - add processName=NTUP option
+#
+# Those commands should be regularly checked and, in case of changes, propagated into this script!
+
+
+cmsDriver.py SinglePiPt25Eta1p7_2p7_cfi  --conditions auto:phase2_realistic \
+  -n 10 --era Phase2C4 --eventcontent FEVTDEBUGHLT --nThreads 4 \
+  -s GEN,SIM,DIGI:pdigi_valid,L1,L1TrackTrigger,DIGI2RAW,HLT:@fake2 \
+  --datatier GEN-SIM --beamspot HLLHC14TeV \
+  --geometry Extended2023D30 \
+  --no_exec --python_filename=GSD_fragment.py
+
+
+cmsDriver.py step3  --conditions auto:phase2_realistic -n 10 \
+  --era Phase2C4 --eventcontent FEVTDEBUGHLT,DQM --runUnscheduled --nThreads 4 \
+  -s RAW2DIGI,L1Reco,RECO,RECOSIM,VALIDATION:@phase2Validation,DQM:@phase2 \
+  --datatier GEN-SIM-RECO,DQMIO --geometry Extended2023D30 \
+  --no_exec --python_filename=RECO_fragment.py
+
+
+cmsDriver.py step3 --conditions auto:phase2_realistic -n 10 \
+  --era Phase2C4 --eventcontent FEVTDEBUGHLT --runUnscheduled \
+  -s RAW2DIGI,L1Reco,RECO,RECOSIM \
+  --datatier GEN-SIM-RECO --geometry Extended2023D30 \
+  --no_exec --python_filename=NTUP_fragment.py \
+  --processName=NTUP


### PR DESCRIPTION
These have been created using `CMSSW_10_3_0_pre1` following instructions in https://indico.cern.ch/event/748252/contributions/3100080/attachments/1698943/2735337/hgcal_software_status_aug_8_2018.pdf