### PR TITLE
Migration to condor

### DIFF
--- a/SubmitFileGSD.sh
+++ b/SubmitFileGSD.sh
@@ -1,13 +1,18 @@
+#!/bin/bash
+export XRD_NETWORKSTACK=IPv4
+
 ## External vars
-curDir=${1}
-outDir=${2}
-cfgFile=${3}
-localFlag=${4}
-CMSSWVER=${5} # CMSSW_8_1_0_pre7
-CMSSWDIR=${6} # ${curDir}/../${CMSSWVER}
-CMSSWARCH=${7} # slc6_amd64_gcc530
-eosArea=${8}
-dataTier=${9}
+clusterid=${1}
+procid=${2}
+curDir=${3}
+outDir=${4}
+cfgFile=${5}
+localFlag=${6}
+CMSSWVER=${7} # CMSSW_8_1_0_pre7
+CMSSWDIR=${8} # ${curDir}/../${CMSSWVER}
+CMSSWARCH=${9} # slc6_amd64_gcc530
+eosArea=${10}
+dataTier=${11}
 
 ##Create Work Area
 export SCRAM_ARCH=${CMSSWARCH}

--- a/submitNextStep.sh
+++ b/submitNextStep.sh
@@ -19,11 +19,11 @@ for i in `ls $SAMPLEDIR`; do
                 echo "Nothing to be done"
             else
                 echo "submit NTUP for $i"
-                python SubmitHGCalPGun.py --datTier NTUP --evtsperjob $EVTSNTUP --queue 8nh --inDir $i
+                python SubmitHGCalPGun.py --datTier NTUP --evtsperjob $EVTSNTUP --queue workday --inDir $i
             fi
         else
             echo "submit RECO for $i"
-            python SubmitHGCalPGun.py --datTier RECO --evtsperjob $EVTSRECO --queue 8nh --inDir $i
+            python SubmitHGCalPGun.py --datTier RECO --evtsperjob $EVTSRECO --queue workday --inDir $i
         fi
     else
         echo "$i does not seem to be a directory containing event samples! Skipping."


### PR DESCRIPTION
HTCondor support for batch jobs is added. A practical guide is here [1]. There are a lot more features than 
LSF, however a practical difference is that a submission file should be specified. For this reason 
apart from the usual (std,cfg) directories a new directory (jobs) is created where the relevant .sub files 
are placed. In [2] I also put some useful info although we should educate ourselves better with this new tool. 

[1] http://batchdocs.web.cern.ch/batchdocs/local/lsfmigratepractical.html

[2] 

Queues
------
espresso     = 20 minutes
microcentury = 1 hour
longlunch    = 2 hours
workday      = 8 hours
tomorrow     = 1 day
testmatch    = 3 days
nextweek     = 1 week

Commands
--------
Removal/kill: condor_rm $USER
monitor like busers/bjobs: condor_q
like bpeek: condor_tail -f -stderr -auto-retry 447074.0 #last is the job id
submit jobs: condor_submit