### PR TITLE
Store the dqm file

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,11 +95,13 @@ python SubmitHGCalPGun.py \
   --queue QUEUENAME \
   --inDir partGun_[MYTAG]_[DATE] \
   [--local] \
-  --tag MYTAG
+  --tag MYTAG \
+  [--keepDQMfile] 
 ```
 
 The script will get the list of GEN-SIM-DIGI files from the directory `partGun_[MYTAG]_[DATE]`/`GSD` (locally or on the CMG EOS area), and submit jobs to queue `QUEUENAME` (if possbile with `NPERJOB` events per job).
 The batch `stdout`/`stderr` files and `.cfg` files are stored locally `in partGun_[MYTAG]_[DATE]`, while the resulting files `partGun_*_RECO_{i}.root` are stored in `partGun_[MYTAG]_[DATE]`/`RECO` either locally or in  `/eos/cms/store/cmst3/group/hgcal/CMG_studies/Production/`.
+In case the `--keepDQMfile` option is used, the resulting `partGun_*_DQM_{i}.root` files will also be stored in `partGun_[MYTAG]_[DATE]`/`DQM` locally or in `/eos/cms/store/cmst3/group/hgcal/CMG_studies/Production/`.
 
 Rule of thumb for RECO: 10 events per `1nh`:
 * 50 events should be possible to finish in queue `8nh`.

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ python SubmitHGCalPGun.py \
   --inDir partGun_[MYTAG]_[DATE] \
   [--local] \
   --tag MYTAG \
-  [--keepDQMfile] 
+  --keepDQMfile 
 ```
 
 The script will get the list of GEN-SIM-DIGI files from the directory `partGun_[MYTAG]_[DATE]`/`GSD` (locally or on the CMG EOS area), and submit jobs to queue `QUEUENAME` (if possbile with `NPERJOB` events per job).

--- a/SubmitFileGSD.sh
+++ b/SubmitFileGSD.sh
@@ -13,6 +13,7 @@ CMSSWDIR=${8} # ${curDir}/../${CMSSWVER}
 CMSSWARCH=${9} # slc6_amd64_gcc530
 eosArea=${10}
 dataTier=${11}
+keepDQMfile=${12}
 
 ##Create Work Area
 export SCRAM_ARCH=${CMSSWARCH}
@@ -34,6 +35,14 @@ cmsRun ${curDir}/${outDir}/cfg/${cfgFile}
 if [ ${localFlag} == "True" ]
   then
     cp *${dataTier}*.root ${curDir}/${outDir}/${dataTier}/
+    if [ ${keepDQMfile} == "True" ]
+	then
+	cp *DQM*.root ${curDir}/${outDir}/DQM/
+    fi
   else
     xrdcp -N -v *${dataTier}*.root root://eoscms.cern.ch/${eosArea}/${outDir}/${dataTier}/
+    if [ ${keepDQMfile} == "True" ]
+	then
+	xrdcp -N -v *DQM*.root root://eoscms.cern.ch/${eosArea}/${outDir}/DQM/
+    fi	
 fi

--- a/templates/partGun_RECO_template.py
+++ b/templates/partGun_RECO_template.py
@@ -9,6 +9,7 @@ process.source.fileNames = cms.untracked.vstring(DUMMYINPUTFILELIST)
 
 # Output definition
 process.FEVTDEBUGHLToutput.fileName = cms.untracked.string('file:DUMMYFILENAME')
+process.DQMoutput.fileName = cms.untracked.string('file:DUMMYDQMFILENAME')
 
 # Customisation from command line
 # process.hgcalLayerClusters.minClusters = cms.uint32(3)


### PR DESCRIPTION
An option is added (`--keepDQMfile`) so that, if used, at the RECO step the DQM file will also be stored locally or in eos in a separate folder. 