### PR TITLE
Updating the closeby gun

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,11 +92,11 @@ one particle are asked to be produced, then each particle will be created at a d
 equally spaced by Delta, the arc-distance between two consecutive vertices 
 over the circle of radius R. Also, there is the `--pointing` option which if used particles will be produced parallel to the beamline,  otherwise they will be pointing to (0,0,0). Furthermore, there is the `--overlapping` option that if used then
 particles will be generated in a window [phiMin,phiMax], [rMin,rMax], otherwise with a DeltaPhi=Delta/R.
-Another option is `--randomshoot` which if used will shoot a random number of particles. However, this option should be used alongside the `--nRandomPart` in order for the gun to know the upper limit on how many particles to shoot. The `--nRandomPart` option shouldn't be confused with the size of the `--partID` option, since with `--partID` we are setting the particles we are interesting in producing, while with `--nRandomPart` we are randomly choosing the number we want to shoot out of those `--partID` ids. 
+Another option is `--randomShoot` which if used will shoot a random number of particles. However, this option should be used alongside the `--nRandomPart` in order for the gun to know the upper limit on how many particles to shoot. The `--nRandomPart` option shouldn't be confused with the size of the `--partID` option, since with `--partID` we are setting the particles we are interesting in producing, while with `--nRandomPart` we are randomly choosing the number we want to shoot out of those `--partID` ids. 
 Apart from producing multiple particles, this gun could also produce a single particle wherever the user wishes, having always the 
 nice feature of assigning to the vertex the time required to travel from (0,0,0) to the desired location. This could be 
 useful e.g. when someone wants to shoot straight to the scintillator part. Keep in mind that in this case there is no sense of 
-neither adding the antiparticle nor adding the `--randomshoot` option. 
+neither adding the antiparticle nor adding the `--randomShoot` option. 
 As an example, the command below will produce `NEVENTS` GEN-SIM-DIGI events with `NPART` sets of particles (per event) of type `PART_PDGID` 
 in the energy range from `EMIN` to `EMAX` (Pt option not available), radius range from `RMIN` to `RMAX`, z position from `ZMIN` to `ZMAX`, parallel to the beamline, with a distance between the particles vertices of deltaPhi = DELTA/R. 
 

--- a/README.md
+++ b/README.md
@@ -86,16 +86,17 @@ Rule of thumb for GEN-SIM-DIGI: 4 events per `1nh`:
 
 ### Close-by gun
 
-Another gun that could be used is `--gunMode closeby`, which is capable of creating several vertices. Mind that it is only available in `CMSSW_10_6_0_pre4` or later.
+Another gun that could be used is `--gunMode closeby`, which is capable of creating several vertices. Mind that it is only available in `CMSSW_10_6_0` or later.
 With this choice particles can be produced with random energy, R and Z in a specified range. When more than 
 one particle are asked to be produced, then each particle will be created at a different vertex, 
 equally spaced by Delta, the arc-distance between two consecutive vertices 
 over the circle of radius R. Also, there is the `--pointing` option which if used particles will be produced parallel to the beamline,  otherwise they will be pointing to (0,0,0). Furthermore, there is the `--overlapping` option that if used then
-particles will be generated in a window [phiMin,phiMax], [rMin,rMax], otherwise with a DeltaPhi=Delta/R. 
+particles will be generated in a window [phiMin,phiMax], [rMin,rMax], otherwise with a DeltaPhi=Delta/R.
+Another option is `--randomshoot` which if used will shoot a random number of particles. However, this option should be used alongside the `--nRandomPart` in order for the gun to know the upper limit on how many particles to shoot. The `--nRandomPart` option shouldn't be confused with the size of the `--partID` option, since with `--partID` we are setting the particles we are interesting in producing, while with `--nRandomPart` we are randomly choosing the number we want to shoot out of those `--partID` ids. 
 Apart from producing multiple particles, this gun could also produce a single particle wherever the user wishes, having always the 
 nice feature of assigning to the vertex the time required to travel from (0,0,0) to the desired location. This could be 
-useful e.g. when someone wants to shoot straight to the scintillator part. Keep in mind that there is no sense of 
-adding the antiparticle. 
+useful e.g. when someone wants to shoot straight to the scintillator part. Keep in mind that in this case there is no sense of 
+neither adding the antiparticle nor adding the `--randomshoot` option. 
 As an example, the command below will produce `NEVENTS` GEN-SIM-DIGI events with `NPART` sets of particles (per event) of type `PART_PDGID` 
 in the energy range from `EMIN` to `EMAX` (Pt option not available), radius range from `RMIN` to `RMAX`, z position from `ZMIN` to `ZMAX`, parallel to the beamline, with a distance between the particles vertices of deltaPhi = DELTA/R. 
 

--- a/SubmitHGCalPGun.py
+++ b/SubmitHGCalPGun.py
@@ -35,8 +35,8 @@ def parseOptions():
     parser.add_option('', '--rMax',  dest='rMax',  type=float, default=300.0,    help='max. r value')
     parser.add_option('', '--pointing',  action='store_false',  dest='pointing',  default=True,    help='pointing to (0,0,0) in case of closeby gun')
     parser.add_option('', '--overlapping',  action='store_true',  dest='overlapping',  default=False,    help='particles will be generated in window [phiMin,phiMax], [rMin,rMax] (true) or with a DeltaPhi=Delta/R (default false) in case of closeby gun')
-    parser.add_option('', '--randomshoot',  action='store_true',  dest='randomshoot',  default=False,    help='if true it will randomly choose one particle in the range [1, NParticles +1 ]')
-    parser.add_option('', '--nRandomPart',  dest='NRANDOMPART',  type=int,   default=1,      help='This is used together with randomshoot to shoot randomly [1, NParticles +1 ] particles, default is 1')
+    parser.add_option('', '--randomShoot',  action='store_true',  dest='randomShoot',  default=False,    help='if true it will randomly choose one particle in the range [1, NParticles +1 ]')
+    parser.add_option('', '--nRandomPart',  dest='NRANDOMPART',  type=int,   default=1,      help='This is used together with randomShoot to shoot randomly [1, NParticles +1 ] particles, default is 1')
     parser.add_option('', '--gunMode',   dest='gunMode',   type='string', default='default',    help='default or pythia8 or closeby')
     parser.add_option('', '--gunType',   dest='gunType',   type='string', default='Pt',    help='Pt or E gun')
     parser.add_option('', '--InConeID', dest='InConeID',   type='string',     default='', help='PDG ID for single particle to be generated in the cone (supported as PARTID), default is empty string (none)')
@@ -151,7 +151,7 @@ def printSetup(CMSSW_BASE, CMSSW_VERSION, SCRAM_ARCH, currentDir, outDir):
     if (opt.InConeID!='' and opt.DTIER=='GSD'):
         print '             IN-CONE: PDG ID '+str(opt.InConeID)+', deltaR in ['+str(opt.MinDeltaR)+ ','+str(opt.MaxDeltaR)+']'+', momentum ratio in ['+str(opt.MinMomRatio)+ ','+str(opt.MaxMomRatio)+']'
     if (opt.gunMode == 'closeby' and opt.DTIER=='GSD'):
-        print '             z threshold in ['+str(opt.zMin)+','+str(opt.zMax)+'], r threshold in ['+str(opt.rMin)+','+str(opt.rMax)+'], pointing to (0,0,0) '+str(opt.pointing) + ', overlapping '+str(opt.overlapping)+ ', randomshoot '+str(opt.randomshoot) + ', nRandomPart '+str(opt.NRANDOMPART) 
+        print '             z threshold in ['+str(opt.zMin)+','+str(opt.zMax)+'], r threshold in ['+str(opt.rMin)+','+str(opt.rMax)+'], pointing to (0,0,0) '+str(opt.pointing) + ', overlapping '+str(opt.overlapping)+ ', randomShoot '+str(opt.randomShoot) + ', nRandomPart '+str(opt.NRANDOMPART) 
     print 'STORE AREA: ', [opt.eosArea, currentDir][int(opt.LOCAL)]
     print 'OUTPUT DIR: ', outDir
     print 'QUEUE:      ', opt.QUEUE
@@ -361,7 +361,7 @@ def submitHGCalProduction():
                     s_template=s_template.replace('DUMMYRMAX',str(opt.rMax))
                     s_template=s_template.replace('DUMMYPOINTING',str(opt.pointing))
                     s_template=s_template.replace('DUMMYOVERLAPPING',str(opt.overlapping))
-                    s_template=s_template.replace('DUMMYRANDOMSHOOT',str(opt.randomshoot))
+                    s_template=s_template.replace('DUMMYRANDOMSHOOT',str(opt.randomShoot))
                     s_template=s_template.replace('DUMMYNRANDOMPARTICLES',str(opt.NRANDOMPART))
 
 

--- a/SubmitHGCalPGun.py
+++ b/SubmitHGCalPGun.py
@@ -35,6 +35,8 @@ def parseOptions():
     parser.add_option('', '--rMax',  dest='rMax',  type=float, default=300.0,    help='max. r value')
     parser.add_option('', '--pointing',  action='store_false',  dest='pointing',  default=True,    help='pointing to (0,0,0) in case of closeby gun')
     parser.add_option('', '--overlapping',  action='store_true',  dest='overlapping',  default=False,    help='particles will be generated in window [phiMin,phiMax], [rMin,rMax] (true) or with a DeltaPhi=Delta/R (default false) in case of closeby gun')
+    parser.add_option('', '--randomshoot',  action='store_true',  dest='randomshoot',  default=False,    help='if true it will randomly choose one particle in the range [1, NParticles +1 ]')
+    parser.add_option('', '--nRandomPart',  dest='NRANDOMPART',  type=int,   default=1,      help='This is used together with randomshoot to shoot randomly [1, NParticles +1 ] particles, default is 1')
     parser.add_option('', '--gunMode',   dest='gunMode',   type='string', default='default',    help='default or pythia8 or closeby')
     parser.add_option('', '--gunType',   dest='gunType',   type='string', default='Pt',    help='Pt or E gun')
     parser.add_option('', '--InConeID', dest='InConeID',   type='string',     default='', help='PDG ID for single particle to be generated in the cone (supported as PARTID), default is empty string (none)')
@@ -149,7 +151,7 @@ def printSetup(CMSSW_BASE, CMSSW_VERSION, SCRAM_ARCH, currentDir, outDir):
     if (opt.InConeID!='' and opt.DTIER=='GSD'):
         print '             IN-CONE: PDG ID '+str(opt.InConeID)+', deltaR in ['+str(opt.MinDeltaR)+ ','+str(opt.MaxDeltaR)+']'+', momentum ratio in ['+str(opt.MinMomRatio)+ ','+str(opt.MaxMomRatio)+']'
     if (opt.gunMode == 'closeby' and opt.DTIER=='GSD'):
-        print '             z threshold in ['+str(opt.zMin)+','+str(opt.zMax)+'], r threshold in ['+str(opt.rMin)+','+str(opt.rMax)+'], pointing to (0,0,0) '+str(opt.pointing) + ', overlapping '+str(opt.overlapping)
+        print '             z threshold in ['+str(opt.zMin)+','+str(opt.zMax)+'], r threshold in ['+str(opt.rMin)+','+str(opt.rMax)+'], pointing to (0,0,0) '+str(opt.pointing) + ', overlapping '+str(opt.overlapping)+ ', randomshoot '+str(opt.randomshoot) + ', nRandomPart '+str(opt.NRANDOMPART) 
     print 'STORE AREA: ', [opt.eosArea, currentDir][int(opt.LOCAL)]
     print 'OUTPUT DIR: ', outDir
     print 'QUEUE:      ', opt.QUEUE
@@ -359,6 +361,8 @@ def submitHGCalProduction():
                     s_template=s_template.replace('DUMMYRMAX',str(opt.rMax))
                     s_template=s_template.replace('DUMMYPOINTING',str(opt.pointing))
                     s_template=s_template.replace('DUMMYOVERLAPPING',str(opt.overlapping))
+                    s_template=s_template.replace('DUMMYRANDOMSHOOT',str(opt.randomshoot))
+                    s_template=s_template.replace('DUMMYNRANDOMPARTICLES',str(opt.NRANDOMPART))
 
 
             elif (opt.DTIER == 'RECO' or opt.DTIER == 'NTUP'):

--- a/templates/partGun_GSD_template.py
+++ b/templates/partGun_GSD_template.py
@@ -67,6 +67,8 @@ elif gunmode == 'closeby':
             Delta = cms.double(DUMMYDELTA),
             Pointing = cms.bool(DUMMYPOINTING),
             Overlapping = cms.bool(DUMMYOVERLAPPING),
+            RandomShoot = cms.bool(DUMMYRANDOMSHOOT),
+            NParticles = cms.int32(DUMMYNRANDOMPARTICLES),
             MaxEta = cms.double(DUMMYETAMAX),
             MinEta = cms.double(DUMMYETAMIN),
             MaxPhi = cms.double(3.14159265359/6.),


### PR DESCRIPTION
In the PR [#26531](https://github.com/cms-sw/cmssw/pull/26531) the CloseByParticleGun was updated and starting from CMSSW_10_6_0 the `closeby` will crash. We update the code and the README file to synchronize with the latest CMSSW version. 

In order to explain the different options of the `closeby` gun this is an example command: 

`python SubmitHGCalPGun.py --datTier GSD --nevts 10 --evtsperjob 2 --queue tomorrow --partID 22,11,13 --nPart 1 --thresholdMin 60 --thresholdMax 60 --etaMin 1.4 --etaMax 3.0 --zMin 429.99 --zMax 430.01 --rMin 179.99 --rMax 180.01 --pointing --randomShoot --nRandomPart 10 --gunType E --gunMode closeby --eosArea /eos/cms/store/user/apsallid/HGCal --tag ${USER}_PDGId22_nPart1_E60_Scint_R180_Z430`

The new options `--randomShoot --nRandomPart 10` tells the gun to choose randomly a number of particles to shoot from 1 to 10, each time with randomly choosing the particle's id from `22,11,13`.

@clelange @rovere @felicepantaleo