### PR TITLE
Fix usage of dEdX weights.

### DIFF
--- a/templates/partGun_NTUP_template.py
+++ b/templates/partGun_NTUP_template.py
@@ -23,7 +23,7 @@ process.ana = cms.EDAnalyzer('HGCalAnalysis',
                              storePFCandidates = cms.bool(DUMMYSPFC),
                              recomputePCA = cms.bool(False),
                              includeHaloPCA = cms.bool(True),
-                             dEdXWeights = dEdX,
+                             dEdXWeights = dEdX.weights,
                              layerClusterPtThreshold = cms.double(-1),  # All LayerCluster belonging to a multicluster are saved; this Pt threshold applied to the others
                              TestParticleFilter = ParticleFilterBlock.ParticleFilter
 )


### PR DESCRIPTION
As of https://github.com/cms-sw/cmssw/commit/9be5bf9c60ce6390f3c1cf172412e228f65d1c64 , dEdX is a `PSet` with a member `weights`. This PR only contains a trivial change to reflect this in the NTUP template.