### PR TITLE
Update to geometry 2026.

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ The third command is a copy of the second only re-running RECO (for NTUP):
 * remove `DQM`
 * add `processName=NTUP` option
 
-For more details see the [configuration files listed above](available-configurations).
+For more details see the [configuration files listed above](#available-configurations).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ For details on the pileup scenario, please see [Configuration/StandardSequences/
 
 | Snippet        | Era            | Geometry       | Beamspot       | PU             |
 | -------------- | -------------- | -------------- | -------------- | -------------- |
-| [produceSkeletons_D41_NoSmear_noPU.sh](templates/python/produceSkeletons_D41_NoSmear_noPU.sh) | Phase2C8_timing_layer_bar | D41 | NoSmear | none |
-| [produceSkeletons_D41_NoSmear_PU_AVE_200_BX_25ns.sh](templates/python/produceSkeletons_D41_NoSmear_PU_AVE_200_BX_25ns.sh) | Phase2C8_timing_layer_bar | D41 | NoSmear | AVE_200_BX_25ns |
-| [produceSkeletons_D41_VtxSmearedHLLHC_noPU.sh](templates/python/produceSkeletons_D41_VtxSmearedHLLHC_noPU.sh) | Phase2C8_timing_layer_bar | D41 | VtxSmearedHLLHC | none |
+| [produceSkeletons_D41_NoSmear_noPU.sh](templates/python/produceSkeletons_D41_NoSmear_noPU.sh) | Phase2C8 | D41 | NoSmear | none |
+| [produceSkeletons_D41_NoSmear_PU_AVE_200_BX_25ns.sh](templates/python/produceSkeletons_D41_NoSmear_PU_AVE_200_BX_25ns.sh) | Phase2C8 | D41 | NoSmear | AVE_200_BX_25ns |
+| [produceSkeletons_D41_VtxSmearedHLLHC_noPU.sh](templates/python/produceSkeletons_D41_VtxSmearedHLLHC_noPU.sh) | Phase2C8 | D41 | VtxSmearedHLLHC | none |
 
 Whenever you would like to change configuration, change to the `reco_prodtools/templates/python` directory and execute the corresponding script. Then make sure to run `scram b`.
 

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ For details on the pileup scenario, please see [Configuration/StandardSequences/
 
 | Snippet        | Era            | Geometry       | Beamspot       | PU             |
 | -------------- | -------------- | -------------- | -------------- | -------------- |
-| [produceSkeletons_D41_NoSmear_noPU.sh](templates/python/produceSkeletons_D41_NoSmear_noPU.sh) | Phase2C8 | D41 | NoSmear | none |
-| [produceSkeletons_D41_NoSmear_PU_AVE_200_BX_25ns.sh](templates/python/produceSkeletons_D41_NoSmear_PU_AVE_200_BX_25ns.sh) | Phase2C8 | D41 | NoSmear | AVE_200_BX_25ns |
-| [produceSkeletons_D41_VtxSmearedHLLHC_noPU.sh](templates/python/produceSkeletons_D41_VtxSmearedHLLHC_noPU.sh) | Phase2C8 | D41 | VtxSmearedHLLHC | none |
+| [produceSkeletons_D41_NoSmear_noPU.sh](templates/python/produceSkeletons_D41_NoSmear_noPU.sh) | Phase2C8_timing_layer_bar | D41 | NoSmear | none |
+| [produceSkeletons_D41_NoSmear_PU_AVE_200_BX_25ns.sh](templates/python/produceSkeletons_D41_NoSmear_PU_AVE_200_BX_25ns.sh) | Phase2C8_timing_layer_bar | D41 | NoSmear | AVE_200_BX_25ns |
+| [produceSkeletons_D41_VtxSmearedHLLHC_noPU.sh](templates/python/produceSkeletons_D41_VtxSmearedHLLHC_noPU.sh) | Phase2C8_timing_layer_bar | D41 | VtxSmearedHLLHC | none |
 
 Whenever you would like to change configuration, change to the `reco_prodtools/templates/python` directory and execute the corresponding script. Then make sure to run `scram b`.
 
@@ -201,17 +201,17 @@ runTheMatrix.py -w upgrade -n | grep D41 | grep SinglePiPt
 This will result in output similar to the following:
 
 ```shell
-29088.0 SinglePiPt25Eta1p7_2p7_2023D41_GenSimHLBeamSpotFull+DigiFullTrigger_2023D41+RecoFullGlobal_2023D41+HARVESTFullGlobal_2023D41
-29288.0 SinglePiPt25Eta1p7_2p7_2023D41PU_GenSimHLBeamSpotFull+DigiFullTriggerPU_2023D41PU+RecoFullGlobalPU_2023D41PU+HARVESTFullGlobalPU_2023D41PU
+20488.0 SinglePiPt25Eta1p7_2p7_2026D41_GenSimHLBeamSpotFull+DigiFullTrigger_2026D41+RecoFullGlobal_2026D41+HARVESTFullGlobal_2026D41
+20688.0 SinglePiPt25Eta1p7_2p7_2026D41PU_GenSimHLBeamSpotFull+DigiFullTriggerPU_2026D41PU+RecoFullGlobalPU_2026D41PU+HARVESTFullGlobalPU_2026D41PU
 ```
 
-In the above case, there are two workflows listed, one with and one without PU. Let's pick the one with PU, `29288.0`, and get the configs:
+In the above case, there are two workflows listed, one with and one without PU. Let's pick the one with PU, `20688.0`, and get the configs:
 
 ```shell
-runTheMatrix.py -w upgrade -l 29288.0 --command="--no_exec" --dryRun
+runTheMatrix.py -w upgrade -l 20688.0 --command="--no_exec" --dryRun
 ```
 
-This will run a while and create a new directory that contains the configs (e.g. `29288.0_SinglePiPt25Eta1p7_2p7+SinglePiPt25Eta1p7_2p7_2023D41PU_GenSimHLBeamSpotFull+DigiFullTriggerPU_2023D41PU+RecoFullGlobalPU_2023D41PU+HARVESTFullGlobalPU_2023D41PU`). Further, several `cmsDriver.py` scripts will be printed out to the screen. These are the ones that need to be adjusted and put into the corresponding shell scripts (have a look at the existing shell scripts themselves).
+This will run a while and create a new directory that contains the configs (e.g. `20688.0_SinglePiPt25Eta1p7_2p7_2026D41PU_GenSimHLBeamSpotFull+DigiFullTriggerPU_2026D41PU+RecoFullGlobalPU_2026D41PU+HARVESTFullGlobalPU_2026D41PU`). Further, several `cmsDriver.py` scripts will be printed out to the screen. These are the ones that need to be adjusted and put into the corresponding shell scripts (have a look at the existing shell scripts themselves).
 
 Some general guidelines:
 
@@ -239,6 +239,8 @@ The third command is a copy of the second only re-running RECO (for NTUP):
 
 * remove `DQM`
 * add `processName=NTUP` option
+
+For more details see the [configuration files listed above](available-configurations).
 
 ## Contributing
 

--- a/templates/python/produceSkeletons_D41_NoSmear_PU_AVE_200_BX_25ns.sh
+++ b/templates/python/produceSkeletons_D41_NoSmear_PU_AVE_200_BX_25ns.sh
@@ -3,7 +3,7 @@
 # This is the shell script that will generate all the skeletons using cmsDriver commands.
 # The commands included have been taken from runTheMatrix with the following command:
 #
-# runTheMatrix.py -w upgrade -l 29234.11 --command="--no_exec" --dryRun
+# runTheMatrix.py -w upgrade -l 20634.0 --command="--no_exec" --dryRun
 #
 # For all commands remove --filein and --fileout options.
 # Add python_filename option
@@ -14,40 +14,59 @@
 # The following changes are implemented on top:
 # --beamspot HLLHC14TeV ➜ --beamspot NoSmear
 # --eventcontent FEVTDEBUG ➜ --eventcontent FEVTDEBUGHLT
+# Removed --relval option.
 #
 # The second command is step3 removing overlap with step2 (RECO):
 # - remove pileup part
-# - also remove MINIAODSIM, PAT
-# - remove from VALIDATION@miniAODValidation
-# - remove from DQM:@miniAODDQM
+# - remove MINIAODSIM from event content and data tier
+# - remove PAT from steps (-s)
+# - remove @miniAODValidation from VALIDATION step
+# - remove @miniAODDQM from DQM step
 #
 # The third command is a copy of the second only re-running RECO (for NTUP):
-# - remove DQM
-# - add processName=NTUP option
+# - remove DQM from event content
+# - remove DQMIO from data tier
+# - add --processName=NTUP option
 #
 # Those commands should be regularly checked and, in case of changes, propagated into this script!
 
-cmsDriver.py TTbar_14TeV_TuneCUETP8M1_cfi  --conditions auto:phase2_realistic \
-  -n 10 --era Phase2C8 --eventcontent FEVTDEBUGHLT \
+cmsDriver.py TTbar_14TeV_TuneCUETP8M1_cfi \
+  --conditions auto:phase2_realistic \
+  -n 10 \
+  --era Phase2C8_timing_layer_bar \
+  --eventcontent FEVTDEBUGHLT \
   -s GEN,SIM,DIGI:pdigi_valid,L1,L1TrackTrigger,DIGI2RAW,HLT:@fake2 \
   --datatier GEN-SIM \
   --beamspot NoSmear \
-  --geometry Extended2023D41 \
+  --geometry Extended2026D41\
   --pileup AVE_200_BX_25ns \
-  --pileup_input das:/RelValMinBias_14TeV/CMSSW_10_4_0_mtd3-103X_upgrade2023_realistic_v2_2023D35noPU_2-v1/GEN-SIM \
-  --no_exec --python_filename=GSD_fragment.py
+  --pileup_input das:/RelValMinBias_14TeV/CMSSW_10_6_0_patch2-106X_upgrade2023_realistic_v3_2023D41noPU-v1/GEN-SIM \
+  --no_exec \
+  --python_filename=GSD_fragment.py
 
 
-cmsDriver.py step3  --conditions auto:phase2_realistic -n 10 \
-  --era Phase2C8 --eventcontent FEVTDEBUGHLT,DQM --runUnscheduled \
-  -s RAW2DIGI,L1Reco,RECO,RECOSIM,PAT,VALIDATION:@phase2Validation,DQM:@phase2 \
-  --datatier GEN-SIM-RECO,DQMIO --geometry Extended2023D41 \
-  --no_exec --python_filename=RECO_fragment.py
+cmsDriver.py step3 \
+  --conditions auto:phase2_realistic \
+  -n 10 \
+  --era Phase2C8_timing_layer_bar \
+  --eventcontent FEVTDEBUGHLT,DQM \
+  --runUnscheduled \
+  -s RAW2DIGI,L1Reco,RECO,RECOSIM,VALIDATION:@phase2Validation,DQM:@phase2 \
+  --datatier GEN-SIM-RECO,DQMIO \
+  --geometry Extended2026D41 \
+  --no_exec \
+  --python_filename=RECO_fragment.py
 
 
-cmsDriver.py step3  --conditions auto:phase2_realistic -n 10 \
-  --era Phase2C8 --eventcontent FEVTDEBUGHLT --runUnscheduled \
+cmsDriver.py step3 \
+  --conditions auto:phase2_realistic \
+  -n 10 \
+  --era Phase2C8_timing_layer_bar \
+  --eventcontent FEVTDEBUGHLT \
+  --runUnscheduled \
   -s RAW2DIGI,L1Reco,RECO,RECOSIM \
-  --datatier GEN-SIM-RECO --geometry Extended2023D41 \
-  --no_exec --python_filename=NTUP_fragment.py \
-  --processName=NTUP
+  --datatier GEN-SIM-RECO \
+  --geometry Extended2026D41 \
+  --no_exec \
+  --processName=NTUP \
+  --python_filename=NTUP_fragment.py

--- a/templates/python/produceSkeletons_D41_NoSmear_PU_AVE_200_BX_25ns.sh
+++ b/templates/python/produceSkeletons_D41_NoSmear_PU_AVE_200_BX_25ns.sh
@@ -38,7 +38,7 @@ cmsDriver.py TTbar_14TeV_TuneCUETP8M1_cfi \
   -s GEN,SIM,DIGI:pdigi_valid,L1,L1TrackTrigger,DIGI2RAW,HLT:@fake2 \
   --datatier GEN-SIM \
   --beamspot NoSmear \
-  --geometry Extended2026D41\
+  --geometry Extended2026D41 \
   --pileup AVE_200_BX_25ns \
   --pileup_input das:/RelValMinBias_14TeV/CMSSW_10_6_0_patch2-106X_upgrade2023_realistic_v3_2023D41noPU-v1/GEN-SIM \
   --no_exec \

--- a/templates/python/produceSkeletons_D41_NoSmear_PU_AVE_200_BX_25ns.sh
+++ b/templates/python/produceSkeletons_D41_NoSmear_PU_AVE_200_BX_25ns.sh
@@ -33,7 +33,7 @@
 cmsDriver.py TTbar_14TeV_TuneCUETP8M1_cfi \
   --conditions auto:phase2_realistic \
   -n 10 \
-  --era Phase2C8_timing_layer_bar \
+  --era Phase2C8 \
   --eventcontent FEVTDEBUGHLT \
   -s GEN,SIM,DIGI:pdigi_valid,L1,L1TrackTrigger,DIGI2RAW,HLT:@fake2 \
   --datatier GEN-SIM \
@@ -48,7 +48,7 @@ cmsDriver.py TTbar_14TeV_TuneCUETP8M1_cfi \
 cmsDriver.py step3 \
   --conditions auto:phase2_realistic \
   -n 10 \
-  --era Phase2C8_timing_layer_bar \
+  --era Phase2C8 \
   --eventcontent FEVTDEBUGHLT,DQM \
   --runUnscheduled \
   -s RAW2DIGI,L1Reco,RECO,RECOSIM,VALIDATION:@phase2Validation,DQM:@phase2 \
@@ -61,7 +61,7 @@ cmsDriver.py step3 \
 cmsDriver.py step3 \
   --conditions auto:phase2_realistic \
   -n 10 \
-  --era Phase2C8_timing_layer_bar \
+  --era Phase2C8 \
   --eventcontent FEVTDEBUGHLT \
   --runUnscheduled \
   -s RAW2DIGI,L1Reco,RECO,RECOSIM \

--- a/templates/python/produceSkeletons_D41_NoSmear_noPU.sh
+++ b/templates/python/produceSkeletons_D41_NoSmear_noPU.sh
@@ -31,7 +31,7 @@
 cmsDriver.py SinglePiPt25Eta1p7_2p7_cfi \
   --conditions auto:phase2_realistic \
   -n 10 \
-  --era Phase2C8_timing_layer_bar \
+  --era Phase2C8 \
   --eventcontent FEVTDEBUGHLT \
   -s GEN,SIM,DIGI:pdigi_valid,L1,L1TrackTrigger,DIGI2RAW,HLT:@fake2 \
   --datatier GEN-SIM \
@@ -44,7 +44,7 @@ cmsDriver.py SinglePiPt25Eta1p7_2p7_cfi \
 cmsDriver.py step3 \
   --conditions auto:phase2_realistic \
   -n 10 \
-  --era Phase2C8_timing_layer_bar \
+  --era Phase2C8 \
   --eventcontent FEVTDEBUGHLT,DQM \
   --runUnscheduled \
   -s RAW2DIGI,L1Reco,RECO,RECOSIM,VALIDATION:@phase2Validation,DQM:@phase2 \
@@ -57,7 +57,7 @@ cmsDriver.py step3 \
 cmsDriver.py step3 \
   --conditions auto:phase2_realistic \
   -n 10 \
-  --era Phase2C8_timing_layer_bar \
+  --era Phase2C8 \
   --eventcontent FEVTDEBUGHLT \
   --runUnscheduled \
   -s RAW2DIGI,L1Reco,RECO,RECOSIM \

--- a/templates/python/produceSkeletons_D41_NoSmear_noPU.sh
+++ b/templates/python/produceSkeletons_D41_NoSmear_noPU.sh
@@ -3,7 +3,7 @@
 # This is the shell script that will generate all the skeletons using cmsDriver commands.
 # The commands included have been taken from runTheMatrix with the following command:
 #
-# runTheMatrix.py -w upgrade -l 29088.0 --command="--no_exec" --dryRun
+# runTheMatrix.py -w upgrade -l 20488.0 --command="--no_exec" --dryRun
 #
 # For all commands remove --filein and --fileout options.
 # Add python_filename option
@@ -13,37 +13,56 @@
 # The following changes are implemented on top:
 # --beamspot HLLHC ➜ --beamspot NoSmear
 # --eventcontent FEVTDEBUG ➜ --eventcontent FEVTDEBUGHLT
+# Removed --relval option.
 #
 # The second command is step3 removing overlap with step2 (RECO):
-# - remove MINIAODSIM, PAT
-# - remove from VALIDATION@miniAODValidation
-# - remove from DQM:@miniAODDQM
+# - remove MINIAODSIM from event content and data tier
+# - remove PAT from steps (-s)
+# - remove @miniAODValidation from VALIDATION step
+# - remove @miniAODDQM from DQM step
 #
 # The third command is a copy of the second only re-running RECO (for NTUP):
-# - remove DQM
-# - add processName=NTUP option
+# - remove DQM from event content
+# - remove DQMIO from data tier
+# - add --processName=NTUP option
 #
 # Those commands should be regularly checked and, in case of changes, propagated into this script!
 
-cmsDriver.py SinglePiPt25Eta1p7_2p7_cfi  --conditions auto:phase2_realistic \
-  -n 10 --era Phase2C8 --eventcontent FEVTDEBUGHLT \
+cmsDriver.py SinglePiPt25Eta1p7_2p7_cfi \
+  --conditions auto:phase2_realistic \
+  -n 10 \
+  --era Phase2C8_timing_layer_bar \
+  --eventcontent FEVTDEBUGHLT \
   -s GEN,SIM,DIGI:pdigi_valid,L1,L1TrackTrigger,DIGI2RAW,HLT:@fake2 \
   --datatier GEN-SIM \
   --beamspot NoSmear \
-  --geometry Extended2023D41 \
-  --no_exec --python_filename=GSD_fragment.py
+  --geometry Extended2026D41 \
+  --no_exec \
+  --python_filename=GSD_fragment.py
 
 
-cmsDriver.py step3  --conditions auto:phase2_realistic -n 10 \
-  --era Phase2C8 --eventcontent FEVTDEBUGHLT,DQM --runUnscheduled \
+cmsDriver.py step3 \
+  --conditions auto:phase2_realistic \
+  -n 10 \
+  --era Phase2C8_timing_layer_bar \
+  --eventcontent FEVTDEBUGHLT,DQM \
+  --runUnscheduled \
   -s RAW2DIGI,L1Reco,RECO,RECOSIM,VALIDATION:@phase2Validation,DQM:@phase2 \
-  --datatier GEN-SIM-RECO,DQMIO --geometry Extended2023D41 \
-  --no_exec --python_filename=RECO_fragment.py
+  --datatier GEN-SIM-RECO,DQMIO \
+  --geometry Extended2026D41 \
+  --no_exec \
+  --python_filename=RECO_fragment.py
 
 
-cmsDriver.py step3  --conditions auto:phase2_realistic -n 10 \
-  --era Phase2C8 --eventcontent FEVTDEBUGHLT --runUnscheduled \
+cmsDriver.py step3 \
+  --conditions auto:phase2_realistic \
+  -n 10 \
+  --era Phase2C8_timing_layer_bar \
+  --eventcontent FEVTDEBUGHLT \
+  --runUnscheduled \
   -s RAW2DIGI,L1Reco,RECO,RECOSIM \
-  --datatier GEN-SIM-RECO --geometry Extended2023D41 \
-  --no_exec --python_filename=NTUP_fragment.py \
-  --processName=NTUP
+  --datatier GEN-SIM-RECO \
+  --geometry Extended2026D41 \
+  --no_exec \
+  --processName=NTUP \
+  --python_filename=NTUP_fragment.py

--- a/templates/python/produceSkeletons_D41_VtxSmearedHLLHC_noPU.sh
+++ b/templates/python/produceSkeletons_D41_VtxSmearedHLLHC_noPU.sh
@@ -3,7 +3,7 @@
 # This is the shell script that will generate all the skeletons using cmsDriver commands.
 # The commands included have been taken from runTheMatrix with the following command:
 #
-# runTheMatrix.py -w upgrade -l 29234.11 --command="--no_exec" --dryRun
+# runTheMatrix.py -w upgrade -l 20634.0 --command="--no_exec" --dryRun
 #
 # For all commands remove --filein and --fileout options.
 # Add python_filename option
@@ -11,38 +11,59 @@
 # The first command combines step1 and step2 (GSD):
 # - run up to DIGI...HLT:@fake2
 # The following changes are implemented on top:
+# --beamspot HLLHC14TeV ➜ --beamspot NoSmear
 # --eventcontent FEVTDEBUG ➜ --eventcontent FEVTDEBUGHLT
+# Removed --relval option.
 #
 # The second command is step3 removing overlap with step2 (RECO):
-# - also remove MINIAODSIM, PAT
-# - remove from VALIDATION@miniAODValidation
-# - remove from DQM:@miniAODDQM
+# - remove pileup part
+# - remove MINIAODSIM from event content and data tier
+# - remove PAT from steps (-s)
+# - remove @miniAODValidation from VALIDATION step
+# - remove @miniAODDQM from DQM step
 #
 # The third command is a copy of the second only re-running RECO (for NTUP):
-# - remove DQM
-# - add processName=NTUP option
+# - remove DQM from event content
+# - remove DQMIO from data tier
+# - add --processName=NTUP option
 #
 # Those commands should be regularly checked and, in case of changes, propagated into this script!
 
-
-cmsDriver.py TTbar_14TeV_TuneCUETP8M1_cfi  --conditions auto:phase2_realistic \
-  -n 10 --era Phase2C8 --eventcontent FEVTDEBUGHLT --nThreads 4 \
+cmsDriver.py TTbar_14TeV_TuneCUETP8M1_cfi \
+  --conditions auto:phase2_realistic \
+  -n 10 \
+  --era Phase2C8_timing_layer_bar \
+  --eventcontent FEVTDEBUGHLT \
   -s GEN,SIM,DIGI:pdigi_valid,L1,L1TrackTrigger,DIGI2RAW,HLT:@fake2 \
-  --datatier GEN-SIM --beamspot HLLHC14TeV \
-  --geometry Extended2023D41 \
-  --no_exec --python_filename=GSD_fragment.py
+  --datatier GEN-SIM \
+  --beamspot HLLHC14TeV \
+  --geometry Extended2026D41\
+  --no_exec \
+  --python_filename=GSD_fragment.py
 
 
-cmsDriver.py step3  --conditions auto:phase2_realistic -n 10 \
-  --era Phase2C8 --eventcontent FEVTDEBUGHLT,DQM --runUnscheduled --nThreads 4 \
+cmsDriver.py step3 \
+  --conditions auto:phase2_realistic \
+  -n 10 \
+  --era Phase2C8_timing_layer_bar \
+  --eventcontent FEVTDEBUGHLT,DQM \
+  --runUnscheduled \
   -s RAW2DIGI,L1Reco,RECO,RECOSIM,VALIDATION:@phase2Validation,DQM:@phase2 \
-  --datatier GEN-SIM-RECO,DQMIO --geometry Extended2023D41 \
-  --no_exec --python_filename=RECO_fragment.py
+  --datatier GEN-SIM-RECO,DQMIO \
+  --geometry Extended2026D41 \
+  --no_exec \
+  --python_filename=RECO_fragment.py
 
 
-cmsDriver.py step3 --conditions auto:phase2_realistic -n 10 \
-  --era Phase2C8 --eventcontent FEVTDEBUGHLT --runUnscheduled \
+cmsDriver.py step3 \
+  --conditions auto:phase2_realistic \
+  -n 10 \
+  --era Phase2C8_timing_layer_bar \
+  --eventcontent FEVTDEBUGHLT \
+  --runUnscheduled \
   -s RAW2DIGI,L1Reco,RECO,RECOSIM \
-  --datatier GEN-SIM-RECO --geometry Extended2023D41 \
-  --no_exec --python_filename=NTUP_fragment.py \
-  --processName=NTUP
+  --datatier GEN-SIM-RECO \
+  --geometry Extended2026D41 \
+  --no_exec \
+  --processName=NTUP \
+  --python_filename=NTUP_fragment.py

--- a/templates/python/produceSkeletons_D41_VtxSmearedHLLHC_noPU.sh
+++ b/templates/python/produceSkeletons_D41_VtxSmearedHLLHC_noPU.sh
@@ -32,7 +32,7 @@
 cmsDriver.py TTbar_14TeV_TuneCUETP8M1_cfi \
   --conditions auto:phase2_realistic \
   -n 10 \
-  --era Phase2C8_timing_layer_bar \
+  --era Phase2C8 \
   --eventcontent FEVTDEBUGHLT \
   -s GEN,SIM,DIGI:pdigi_valid,L1,L1TrackTrigger,DIGI2RAW,HLT:@fake2 \
   --datatier GEN-SIM \
@@ -45,7 +45,7 @@ cmsDriver.py TTbar_14TeV_TuneCUETP8M1_cfi \
 cmsDriver.py step3 \
   --conditions auto:phase2_realistic \
   -n 10 \
-  --era Phase2C8_timing_layer_bar \
+  --era Phase2C8 \
   --eventcontent FEVTDEBUGHLT,DQM \
   --runUnscheduled \
   -s RAW2DIGI,L1Reco,RECO,RECOSIM,VALIDATION:@phase2Validation,DQM:@phase2 \
@@ -58,7 +58,7 @@ cmsDriver.py step3 \
 cmsDriver.py step3 \
   --conditions auto:phase2_realistic \
   -n 10 \
-  --era Phase2C8_timing_layer_bar \
+  --era Phase2C8 \
   --eventcontent FEVTDEBUGHLT \
   --runUnscheduled \
   -s RAW2DIGI,L1Reco,RECO,RECOSIM \

--- a/templates/python/produceSkeletons_D41_VtxSmearedHLLHC_noPU.sh
+++ b/templates/python/produceSkeletons_D41_VtxSmearedHLLHC_noPU.sh
@@ -37,7 +37,7 @@ cmsDriver.py TTbar_14TeV_TuneCUETP8M1_cfi \
   -s GEN,SIM,DIGI:pdigi_valid,L1,L1TrackTrigger,DIGI2RAW,HLT:@fake2 \
   --datatier GEN-SIM \
   --beamspot HLLHC14TeV \
-  --geometry Extended2026D41\
+  --geometry Extended2026D41 \
   --no_exec \
   --python_filename=GSD_fragment.py
 


### PR DESCRIPTION
This PR updates the scripts that create the configuration templates in https://github.com/CMS-HGCAL/reco-prodtools/tree/master/templates/python to use the new geometry naming `2023` → `2026`. I tested this by running the GSD, RECO and NTUP steps.

Also, I moved all `cmsDriver.py` options to separate lines so that comparisons between them become a little more convenient in the future. I updated the README accordingly.

When merged, this fixes #68.