### PR TITLE
Inject ticl into the RECO fragment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ For details on the pileup scenario, please see [Configuration/StandardSequences/
 
 Whenever you would like to change configuration, change to the `reco_prodtools/templates/python` directory and execute the corresponding script. Then make sure to run `scram b`.
 
+The processing of TICL iterations is added into the RECO fragment by default. To disable that, add `no-ticl` to the skeleton creation script, e.g.:
+
+```shell
+./produceSkeletons_D41_NoSmear_noPU.sh no-ticl
+```
+
 ## Details
 
 To produce `NEVENTS` GEN-SIM-DIGI events with `NPART` sets of particles (per event) of type `PART_PDGID` and in the p_T range from `PTMIN` to `PTMAX`, one should run:

--- a/templates/python/inject_ticl.sh
+++ b/templates/python/inject_ticl.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# This script injects the lines required to run ticl into a
+# reconstruction fragment obtained through (e.g.) runTheMatrix.py.
+#
+# A function is used to be able to use local variables.
+#
+# Arguments:
+#   1. fragment_file: The file to update inline.
+
+action() {
+    # get and check arguments
+    local fragment_file="$1"
+    if [ -z "$fragment_file" ]; then
+        2>&1 echo "please pass a fragment file as argument 1"
+        return "1"
+    fi
+    if [ ! -f "$fragment_file" ]; then
+        2>&1 echo "the fragment file '$fragment_file' does not exist"
+        return "2"
+    fi
+
+    # define what to inject where
+    local hook="# customisation of the process."
+    local content="\n# run TICL\nfrom RecoHGCal.TICL.ticl_iterations import TICL_iterations_withReco\nprocess = TICL_iterations_withReco(process)"
+
+    # do the injection
+    sed "/$hook/a $content" -i "$fragment_file"
+}
+action "$@"

--- a/templates/python/inject_ticl.sh
+++ b/templates/python/inject_ticl.sh
@@ -22,7 +22,7 @@ action() {
 
     # define what to inject where
     local hook="# customisation of the process."
-    local content="\n# run TICL\nfrom RecoHGCal.TICL.ticl_iterations import TICL_iterations_withReco\nprocess = TICL_iterations_withReco(process)"
+    local content="# run TICL\nfrom RecoHGCal.TICL.ticl_iterations import TICL_iterations_withReco\nprocess = TICL_iterations_withReco(process)"
 
     # do the injection
     sed "/$hook/a $content" -i "$fragment_file"

--- a/templates/python/produceSkeletons_D41_NoSmear_PU_AVE_200_BX_25ns.sh
+++ b/templates/python/produceSkeletons_D41_NoSmear_PU_AVE_200_BX_25ns.sh
@@ -5,6 +5,8 @@
 #
 # runTheMatrix.py -w upgrade -l 20634.0 --command="--no_exec" --dryRun
 #
+# The reconstruction as part of the ticl framework is injected into the RECO_fragment.
+#
 # For all commands remove --filein and --fileout options.
 # Add python_filename option
 #
@@ -56,6 +58,8 @@ cmsDriver.py step3 \
   --geometry Extended2026D41 \
   --no_exec \
   --python_filename=RECO_fragment.py
+
+./inject_ticl.sh RECO_fragment.py
 
 
 cmsDriver.py step3 \

--- a/templates/python/produceSkeletons_D41_NoSmear_PU_AVE_200_BX_25ns.sh
+++ b/templates/python/produceSkeletons_D41_NoSmear_PU_AVE_200_BX_25ns.sh
@@ -32,45 +32,74 @@
 #
 # Those commands should be regularly checked and, in case of changes, propagated into this script!
 
-cmsDriver.py TTbar_14TeV_TuneCUETP8M1_cfi \
-  --conditions auto:phase2_realistic \
-  -n 10 \
-  --era Phase2C8 \
-  --eventcontent FEVTDEBUGHLT \
-  -s GEN,SIM,DIGI:pdigi_valid,L1,L1TrackTrigger,DIGI2RAW,HLT:@fake2 \
-  --datatier GEN-SIM \
-  --beamspot NoSmear \
-  --geometry Extended2026D41 \
-  --pileup AVE_200_BX_25ns \
-  --pileup_input das:/RelValMinBias_14TeV/CMSSW_10_6_0_patch2-106X_upgrade2023_realistic_v3_2023D41noPU-v1/GEN-SIM \
-  --no_exec \
-  --python_filename=GSD_fragment.py
+action() {
+  # default arguments
+  local inject_ticl="1"
+
+  # parse arguments
+  for arg in "$@"; do
+    if [ "$arg" = "ticl" ]; then
+      inject_ticl="1"
+    elif [ "$arg" = "no-ticl" ]; then
+      inject_ticl="0"
+    else
+      2>&1 echo "unknown argument: $arg"
+      return "1"
+    fi
+  done
 
 
-cmsDriver.py step3 \
-  --conditions auto:phase2_realistic \
-  -n 10 \
-  --era Phase2C8 \
-  --eventcontent FEVTDEBUGHLT,DQM \
-  --runUnscheduled \
-  -s RAW2DIGI,L1Reco,RECO,RECOSIM,VALIDATION:@phase2Validation,DQM:@phase2 \
-  --datatier GEN-SIM-RECO,DQMIO \
-  --geometry Extended2026D41 \
-  --no_exec \
-  --python_filename=RECO_fragment.py
+  cmsDriver.py TTbar_14TeV_TuneCUETP8M1_cfi \
+    --conditions auto:phase2_realistic \
+    -n 10 \
+    --era Phase2C8 \
+    --eventcontent FEVTDEBUGHLT \
+    -s GEN,SIM,DIGI:pdigi_valid,L1,L1TrackTrigger,DIGI2RAW,HLT:@fake2 \
+    --datatier GEN-SIM \
+    --beamspot NoSmear \
+    --geometry Extended2026D41 \
+    --pileup AVE_200_BX_25ns \
+    --pileup_input das:/RelValMinBias_14TeV/CMSSW_10_6_0_patch2-106X_upgrade2023_realistic_v3_2023D41noPU-v1/GEN-SIM \
+    --no_exec \
+    --python_filename=GSD_fragment.py
 
-./inject_ticl.sh RECO_fragment.py || 2>&1 echo -e "\nticl injection failed\n"
+
+  cmsDriver.py step3 \
+    --conditions auto:phase2_realistic \
+    -n 10 \
+    --era Phase2C8 \
+    --eventcontent FEVTDEBUGHLT,DQM \
+    --runUnscheduled \
+    -s RAW2DIGI,L1Reco,RECO,RECOSIM,VALIDATION:@phase2Validation,DQM:@phase2 \
+    --datatier GEN-SIM-RECO,DQMIO \
+    --geometry Extended2026D41 \
+    --no_exec \
+    --python_filename=RECO_fragment.py
 
 
-cmsDriver.py step3 \
-  --conditions auto:phase2_realistic \
-  -n 10 \
-  --era Phase2C8 \
-  --eventcontent FEVTDEBUGHLT \
-  --runUnscheduled \
-  -s RAW2DIGI,L1Reco,RECO,RECOSIM \
-  --datatier GEN-SIM-RECO \
-  --geometry Extended2026D41 \
-  --no_exec \
-  --processName=NTUP \
-  --python_filename=NTUP_fragment.py
+  if [ "$inject_ticl" = "1" ]; then
+    echo -e "\ninject ticl into RECO_fragment.py"
+    ./inject_ticl.sh RECO_fragment.py
+    if [ "$?" = "0" ]; then
+      echo
+    else
+      2>&1 echo "ticl injection failed"
+      return "2"
+    fi
+  fi
+
+
+  cmsDriver.py step3 \
+    --conditions auto:phase2_realistic \
+    -n 10 \
+    --era Phase2C8 \
+    --eventcontent FEVTDEBUGHLT \
+    --runUnscheduled \
+    -s RAW2DIGI,L1Reco,RECO,RECOSIM \
+    --datatier GEN-SIM-RECO \
+    --geometry Extended2026D41 \
+    --no_exec \
+    --processName=NTUP \
+    --python_filename=NTUP_fragment.py
+}
+action "$@"

--- a/templates/python/produceSkeletons_D41_NoSmear_PU_AVE_200_BX_25ns.sh
+++ b/templates/python/produceSkeletons_D41_NoSmear_PU_AVE_200_BX_25ns.sh
@@ -59,7 +59,7 @@ cmsDriver.py step3 \
   --no_exec \
   --python_filename=RECO_fragment.py
 
-./inject_ticl.sh RECO_fragment.py
+./inject_ticl.sh RECO_fragment.py || 2>&1 echo -e "\nticl injection failed\n"
 
 
 cmsDriver.py step3 \

--- a/templates/python/produceSkeletons_D41_NoSmear_noPU.sh
+++ b/templates/python/produceSkeletons_D41_NoSmear_noPU.sh
@@ -5,6 +5,8 @@
 #
 # runTheMatrix.py -w upgrade -l 20488.0 --command="--no_exec" --dryRun
 #
+# The reconstruction as part of the ticl framework is injected into the RECO_fragment.
+#
 # For all commands remove --filein and --fileout options.
 # Add python_filename option
 #
@@ -52,6 +54,8 @@ cmsDriver.py step3 \
   --geometry Extended2026D41 \
   --no_exec \
   --python_filename=RECO_fragment.py
+
+./inject_ticl.sh RECO_fragment.py
 
 
 cmsDriver.py step3 \

--- a/templates/python/produceSkeletons_D41_NoSmear_noPU.sh
+++ b/templates/python/produceSkeletons_D41_NoSmear_noPU.sh
@@ -55,7 +55,7 @@ cmsDriver.py step3 \
   --no_exec \
   --python_filename=RECO_fragment.py
 
-./inject_ticl.sh RECO_fragment.py
+./inject_ticl.sh RECO_fragment.py || 2>&1 echo -e "\nticl injection failed\n"
 
 
 cmsDriver.py step3 \

--- a/templates/python/produceSkeletons_D41_NoSmear_noPU.sh
+++ b/templates/python/produceSkeletons_D41_NoSmear_noPU.sh
@@ -30,43 +30,72 @@
 #
 # Those commands should be regularly checked and, in case of changes, propagated into this script!
 
-cmsDriver.py SinglePiPt25Eta1p7_2p7_cfi \
-  --conditions auto:phase2_realistic \
-  -n 10 \
-  --era Phase2C8 \
-  --eventcontent FEVTDEBUGHLT \
-  -s GEN,SIM,DIGI:pdigi_valid,L1,L1TrackTrigger,DIGI2RAW,HLT:@fake2 \
-  --datatier GEN-SIM \
-  --beamspot NoSmear \
-  --geometry Extended2026D41 \
-  --no_exec \
-  --python_filename=GSD_fragment.py
+action() {
+  # default arguments
+  local inject_ticl="1"
+
+  # parse arguments
+  for arg in "$@"; do
+    if [ "$arg" = "ticl" ]; then
+      inject_ticl="1"
+    elif [ "$arg" = "no-ticl" ]; then
+      inject_ticl="0"
+    else
+      2>&1 echo "unknown argument: $arg"
+      return "1"
+    fi
+  done
 
 
-cmsDriver.py step3 \
-  --conditions auto:phase2_realistic \
-  -n 10 \
-  --era Phase2C8 \
-  --eventcontent FEVTDEBUGHLT,DQM \
-  --runUnscheduled \
-  -s RAW2DIGI,L1Reco,RECO,RECOSIM,VALIDATION:@phase2Validation,DQM:@phase2 \
-  --datatier GEN-SIM-RECO,DQMIO \
-  --geometry Extended2026D41 \
-  --no_exec \
-  --python_filename=RECO_fragment.py
-
-./inject_ticl.sh RECO_fragment.py || 2>&1 echo -e "\nticl injection failed\n"
+  cmsDriver.py SinglePiPt25Eta1p7_2p7_cfi \
+    --conditions auto:phase2_realistic \
+    -n 10 \
+    --era Phase2C8 \
+    --eventcontent FEVTDEBUGHLT \
+    -s GEN,SIM,DIGI:pdigi_valid,L1,L1TrackTrigger,DIGI2RAW,HLT:@fake2 \
+    --datatier GEN-SIM \
+    --beamspot NoSmear \
+    --geometry Extended2026D41 \
+    --no_exec \
+    --python_filename=GSD_fragment.py
 
 
-cmsDriver.py step3 \
-  --conditions auto:phase2_realistic \
-  -n 10 \
-  --era Phase2C8 \
-  --eventcontent FEVTDEBUGHLT \
-  --runUnscheduled \
-  -s RAW2DIGI,L1Reco,RECO,RECOSIM \
-  --datatier GEN-SIM-RECO \
-  --geometry Extended2026D41 \
-  --no_exec \
-  --processName=NTUP \
-  --python_filename=NTUP_fragment.py
+  cmsDriver.py step3 \
+    --conditions auto:phase2_realistic \
+    -n 10 \
+    --era Phase2C8 \
+    --eventcontent FEVTDEBUGHLT,DQM \
+    --runUnscheduled \
+    -s RAW2DIGI,L1Reco,RECO,RECOSIM,VALIDATION:@phase2Validation,DQM:@phase2 \
+    --datatier GEN-SIM-RECO,DQMIO \
+    --geometry Extended2026D41 \
+    --no_exec \
+    --python_filename=RECO_fragment.py
+
+
+  if [ "$inject_ticl" = "1" ]; then
+    echo -e "\ninject ticl into RECO_fragment.py"
+    ./inject_ticl.sh RECO_fragment.py
+    if [ "$?" = "0" ]; then
+      echo
+    else
+      2>&1 echo "ticl injection failed"
+      return "2"
+    fi
+  fi
+
+
+  cmsDriver.py step3 \
+    --conditions auto:phase2_realistic \
+    -n 10 \
+    --era Phase2C8 \
+    --eventcontent FEVTDEBUGHLT \
+    --runUnscheduled \
+    -s RAW2DIGI,L1Reco,RECO,RECOSIM \
+    --datatier GEN-SIM-RECO \
+    --geometry Extended2026D41 \
+    --no_exec \
+    --processName=NTUP \
+    --python_filename=NTUP_fragment.py
+}
+action "$@"

--- a/templates/python/produceSkeletons_D41_VtxSmearedHLLHC_noPU.sh
+++ b/templates/python/produceSkeletons_D41_VtxSmearedHLLHC_noPU.sh
@@ -5,6 +5,8 @@
 #
 # runTheMatrix.py -w upgrade -l 20634.0 --command="--no_exec" --dryRun
 #
+# The reconstruction as part of the ticl framework is injected into the RECO_fragment.
+#
 # For all commands remove --filein and --fileout options.
 # Add python_filename option
 #
@@ -53,6 +55,8 @@ cmsDriver.py step3 \
   --geometry Extended2026D41 \
   --no_exec \
   --python_filename=RECO_fragment.py
+
+./inject_ticl.sh RECO_fragment.py
 
 
 cmsDriver.py step3 \

--- a/templates/python/produceSkeletons_D41_VtxSmearedHLLHC_noPU.sh
+++ b/templates/python/produceSkeletons_D41_VtxSmearedHLLHC_noPU.sh
@@ -56,7 +56,7 @@ cmsDriver.py step3 \
   --no_exec \
   --python_filename=RECO_fragment.py
 
-./inject_ticl.sh RECO_fragment.py
+./inject_ticl.sh RECO_fragment.py || 2>&1 echo -e "\nticl injection failed\n"
 
 
 cmsDriver.py step3 \

--- a/templates/python/produceSkeletons_D41_VtxSmearedHLLHC_noPU.sh
+++ b/templates/python/produceSkeletons_D41_VtxSmearedHLLHC_noPU.sh
@@ -31,43 +31,72 @@
 #
 # Those commands should be regularly checked and, in case of changes, propagated into this script!
 
-cmsDriver.py TTbar_14TeV_TuneCUETP8M1_cfi \
-  --conditions auto:phase2_realistic \
-  -n 10 \
-  --era Phase2C8 \
-  --eventcontent FEVTDEBUGHLT \
-  -s GEN,SIM,DIGI:pdigi_valid,L1,L1TrackTrigger,DIGI2RAW,HLT:@fake2 \
-  --datatier GEN-SIM \
-  --beamspot HLLHC14TeV \
-  --geometry Extended2026D41 \
-  --no_exec \
-  --python_filename=GSD_fragment.py
+action() {
+  # default arguments
+  local inject_ticl="1"
+
+  # parse arguments
+  for arg in "$@"; do
+    if [ "$arg" = "ticl" ]; then
+      inject_ticl="1"
+    elif [ "$arg" = "no-ticl" ]; then
+      inject_ticl="0"
+    else
+      2>&1 echo "unknown argument: $arg"
+      return "1"
+    fi
+  done
 
 
-cmsDriver.py step3 \
-  --conditions auto:phase2_realistic \
-  -n 10 \
-  --era Phase2C8 \
-  --eventcontent FEVTDEBUGHLT,DQM \
-  --runUnscheduled \
-  -s RAW2DIGI,L1Reco,RECO,RECOSIM,VALIDATION:@phase2Validation,DQM:@phase2 \
-  --datatier GEN-SIM-RECO,DQMIO \
-  --geometry Extended2026D41 \
-  --no_exec \
-  --python_filename=RECO_fragment.py
-
-./inject_ticl.sh RECO_fragment.py || 2>&1 echo -e "\nticl injection failed\n"
+  cmsDriver.py TTbar_14TeV_TuneCUETP8M1_cfi \
+    --conditions auto:phase2_realistic \
+    -n 10 \
+    --era Phase2C8 \
+    --eventcontent FEVTDEBUGHLT \
+    -s GEN,SIM,DIGI:pdigi_valid,L1,L1TrackTrigger,DIGI2RAW,HLT:@fake2 \
+    --datatier GEN-SIM \
+    --beamspot HLLHC14TeV \
+    --geometry Extended2026D41 \
+    --no_exec \
+    --python_filename=GSD_fragment.py
 
 
-cmsDriver.py step3 \
-  --conditions auto:phase2_realistic \
-  -n 10 \
-  --era Phase2C8 \
-  --eventcontent FEVTDEBUGHLT \
-  --runUnscheduled \
-  -s RAW2DIGI,L1Reco,RECO,RECOSIM \
-  --datatier GEN-SIM-RECO \
-  --geometry Extended2026D41 \
-  --no_exec \
-  --processName=NTUP \
-  --python_filename=NTUP_fragment.py
+  cmsDriver.py step3 \
+    --conditions auto:phase2_realistic \
+    -n 10 \
+    --era Phase2C8 \
+    --eventcontent FEVTDEBUGHLT,DQM \
+    --runUnscheduled \
+    -s RAW2DIGI,L1Reco,RECO,RECOSIM,VALIDATION:@phase2Validation,DQM:@phase2 \
+    --datatier GEN-SIM-RECO,DQMIO \
+    --geometry Extended2026D41 \
+    --no_exec \
+    --python_filename=RECO_fragment.py
+
+
+  if [ "$inject_ticl" = "1" ]; then
+    echo -e "\ninject ticl into RECO_fragment.py"
+    ./inject_ticl.sh RECO_fragment.py
+    if [ "$?" = "0" ]; then
+      echo
+    else
+      2>&1 echo "ticl injection failed"
+      return "2"
+    fi
+  fi
+
+
+  cmsDriver.py step3 \
+    --conditions auto:phase2_realistic \
+    -n 10 \
+    --era Phase2C8 \
+    --eventcontent FEVTDEBUGHLT \
+    --runUnscheduled \
+    -s RAW2DIGI,L1Reco,RECO,RECOSIM \
+    --datatier GEN-SIM-RECO \
+    --geometry Extended2026D41 \
+    --no_exec \
+    --processName=NTUP \
+    --python_filename=NTUP_fragment.py
+}
+action "$@"


### PR DESCRIPTION
This PR adds the HGCal reconstruction performed in the TICL framework into the generated RECO fragment.

The injected lines are taken from the [HGCal docs](http://hgcal.web.cern.ch/hgcal/Reconstruction/TICL/).

I used a separate script to do the injection to keep redundancy low.