### PR TITLE
Allow functionality of SubmitHGCalPGun.py to be used externally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
+*.pyc
 templates/python/__init__.py
-templates/python/__init__.pyc
-
 templates/python/*_fragment.py
-templates/python/*_fragment.pyc

--- a/SubmitHGCalPGun.py
+++ b/SubmitHGCalPGun.py
@@ -61,9 +61,10 @@ def createParser():
 
 
 ### parsing input options
-def parseOptions(opt=None):
-    if not opt:
+def parseOptions(parser=None, opt=None):
+    if not parser:
         parser = createParser()
+    if not opt:
         opt, _ = parser.parse_args()
 
     # sanity check for data tiers
@@ -184,8 +185,8 @@ def getInputFileList(DASquery,inPath, inSubDir, local, pattern):
     return inputList
 
 ### submission of GSD/RECO production
-def submitHGCalProduction(opt=None):
-    opt = parseOptions(opt=opt)
+def submitHGCalProduction(*args, **kwargs):
+    opt = parseOptions(*args, **kwargs)
 
     # save working dir
     currentDir = os.getcwd()


### PR DESCRIPTION
This PR disentangles the SubmitHGCalPGun.py script from the contained option parser so that the mechanism to build GSD config files can be used externally, such as by the https://github.com/CMS-HGCAL/hgcalsim tool.

Also, this PR contains some cleanup regarding the treatment of requested particle ids.