### PR TITLE
Output naming

### DIFF
--- a/SubmitHGCalPGun.py
+++ b/SubmitHGCalPGun.py
@@ -88,6 +88,10 @@ def parseOptions(parser=None, opt=None):
         parser.error('Particle gun type ' + opt.gunType + ' is not supported. Exiting...')
         sys.exit()
 
+    # Set upper threshold to lower value if upper one not set
+    if opt.thresholdMax < 0:
+        opt.thresholdMax = opt.thresholdMin
+
     # set the default config, if not specified in options
     if (opt.CONFIGFILE == ''):
         opt.CONFIGFILE = 'templates/partGun_'+opt.DTIER+'_template.py'
@@ -354,7 +358,7 @@ def submitHGCalProduction(*args, **kwargs):
 
             s_template=s_template.replace('DUMMYIDs',nParticles)
             s_template=s_template.replace('DUMMYTHRESHMIN',str(opt.thresholdMin))
-            s_template=s_template.replace('DUMMYTHRESHMAX',str(opt.thresholdMax if opt.thresholdMax >= 0 else opt.thresholdMin))
+            s_template=s_template.replace('DUMMYTHRESHMAX',str(opt.thresholdMax))
             s_template=s_template.replace('DUMMYETAMIN',str(opt.etaMin))
             s_template=s_template.replace('DUMMYETAMAX',str(opt.etaMax))
             s_template=s_template.replace('GUNPRODUCERTYPE',str(partGunType))

--- a/SubmitHGCalPGun.py
+++ b/SubmitHGCalPGun.py
@@ -306,7 +306,7 @@ def submitHGCalProduction(*args, **kwargs):
     processDetails = '_PDGid'+'_id'.join(sParticle)
     if opt.gunMode == 'physproc':
         processDetails = '_'.join(opt.gunType.split(':'))
-    cutsApplied = '_' + opt.gunType + str(opt.thresholdMin) + 'To' + str(opt.thresholdMax)
+    cutsApplied = '_' + opt.gunType + str(opt.thresholdMin) + 'To' + str(opt.thresholdMax) + '_'
     # in case of 'RECO' or 'NTUP', get the input file list for given particle, determine number of jobs, get also basic GSD/RECO info
     if (opt.DTIER == 'RECO' or opt.DTIER == 'NTUP'):
         inputFilesList = getInputFileList(DASquery, inPath, previousDataTier, opt.LOCAL, '*.root')

--- a/templates/partGun_GSD_template.py
+++ b/templates/partGun_GSD_template.py
@@ -48,8 +48,8 @@ elif gunmode == 'pythia8':
           MaxPhi = cms.double(3.14159265359),
           MINTHRESHSTRING = cms.double(DUMMYTHRESHMIN),
           MAXTHRESHSTRING = cms.double(DUMMYTHRESHMAX),
-          MinEta = cms.double(1.479),
-          MaxEta = cms.double(3.0)
+          MinEta = cms.double(DUMMYETAMIN),
+          MaxEta = cms.double(DUMMYETAMAX)
           ),
         PythiaParameters = cms.PSet(parameterSets = cms.vstring())
     )


### PR DESCRIPTION
- Set upper threshold to lower threshold already when parsing options if upper one not provided so that the output file name does not contain `-1.0` as upper threshold but rather the actual threshold applied
- Streamline file naming and parsing for subsequent jobs: Make regex more robust and capable of handling physproc

closes #77 