### PR TITLE
Align phi ranges in CloseByParticleGunProducer with those in CMSSW

### DIFF
--- a/templates/partGun_GSD_template.py
+++ b/templates/partGun_GSD_template.py
@@ -71,8 +71,8 @@ elif gunmode == 'closeby':
             NParticles = cms.int32(DUMMYNRANDOMPARTICLES),
             MaxEta = cms.double(DUMMYETAMAX),
             MinEta = cms.double(DUMMYETAMIN),
-            MaxPhi = cms.double(3.14159265359/6.),
-            MinPhi = cms.double(-3.14159265359/6.)
+            MaxPhi = cms.double(3.14159265359),
+            MinPhi = cms.double(-3.14159265359)
         ),
         Verbosity = cms.untracked.int32(10),
         psethack = cms.string('single or multiple particles predefined E moving vertex'),


### PR DESCRIPTION
@apsallid pointed out that the phi ranges are not the same in the GSD template w.r.t. the ones in CMSSW:

- https://github.com/cms-sw/cmssw/blob/master/Configuration/Generator/python/CE_E_Front_120um_cfi.py
- https://github.com/cms-sw/cmssw/blob/master/Configuration/Generator/python/CE_E_Front_200um_cfi.py
- https://github.com/cms-sw/cmssw/blob/master/Configuration/Generator/python/CE_E_Front_300um_cfi.py
- https://github.com/cms-sw/cmssw/blob/master/Configuration/Generator/python/CE_H_Coarse_300um_cfi.py
- https://github.com/cms-sw/cmssw/blob/master/Configuration/Generator/python/CE_H_Coarse_Scint_cfi.py
- https://github.com/cms-sw/cmssw/blob/master/Configuration/Generator/python/CE_H_Fine_120um_cfi.py
- https://github.com/cms-sw/cmssw/blob/master/Configuration/Generator/python/CE_H_Fine_200um_cfi.py
- https://github.com/cms-sw/cmssw/blob/master/Configuration/Generator/python/CE_H_Fine_300um_cfi.py

This PR rectifies this.

@apsallid Could you please confirm that this is what you intended?

FYI @amartelli @rovere @felicepantaleo @gouskos (re mail)