### PR TITLE
Fix use of tag option in RECO and NTUP steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,13 +199,13 @@ python SubmitHGCalPGun.py \
   --queue QUEUENAME \
   --inDir partGun_[MYTAG]_[DATE] \
   [--local] \
-  --tag MYTAG \
+  [--tag NEWTAG] \
   --keepDQMfile
 ```
 
-The script will get the list of GEN-SIM-DIGI files from the directory `partGun_[MYTAG]_[DATE]`/`GSD` (locally or on the CMG EOS area), and submit jobs to queue `QUEUENAME` (if possbile with `NPERJOB` events per job).
-The batch `stdout`/`stderr` files and `.cfg` files are stored locally `in partGun_[MYTAG]_[DATE]`, while the resulting files `partGun_*_RECO_{i}.root` are stored in `partGun_[MYTAG]_[DATE]`/`RECO` either locally or in  `/eos/cms/store/cmst3/group/hgcal/CMG_studies/Production/`.
-In case the `--keepDQMfile` option is used, the resulting `partGun_*_DQM_{i}.root` files will also be stored in `partGun_[MYTAG]_[DATE]`/`DQM` locally or in `/eos/cms/store/cmst3/group/hgcal/CMG_studies/Production/`.
+The script will get the list of GEN-SIM-DIGI files from the directory `partGun_[MYTAG]_[DATE]`/`GSD` (locally or on the CMG EOS area), and submit jobs to queue `QUEUENAME` (if possible with `NPERJOB` events per job).
+The batch `stdout`/`stderr` files and `.cfg` files are stored locally `in partGun_[MYTAG]_[DATE]`, while the resulting files `partGun_*_RECO_{i}.root` are stored in `partGun_[MYTAG]_[DATE]_[NEWTAG]`/`RECO` (`_NEWTAG` is only added if `--tag` is used) either locally or in  `/eos/cms/store/cmst3/group/hgcal/CMG_studies/Production/`.
+In case the `--keepDQMfile` option is used, the resulting `partGun_*_DQM_{i}.root` files will also be stored in `partGun_[MYTAG]_[DATE]_[NEWTAG]`/`DQM` locally or in `/eos/cms/store/cmst3/group/hgcal/CMG_studies/Production/`.
 
 Rule of thumb for RECO: 10 events per `1nh`:
 
@@ -229,7 +229,7 @@ python SubmitHGCalPGun.py \
   [--multiClusterTag hgcalLayerClusters] \
   [--noReClust] \
   [--local] \
-  --tag MYTAG
+  [--tag NEWTAG]
 ```
 
 Mind that the `multiClusterTag` option needs to be provided for RECO files created before `CMSSW_10_3_X`.

--- a/SubmitHGCalPGun.py
+++ b/SubmitHGCalPGun.py
@@ -257,7 +257,13 @@ def submitHGCalProduction(*args, **kwargs):
             sys.exit()
     elif (opt.DTIER == 'RECO' or opt.DTIER == 'NTUP'):
         if not DASquery:
-            outDir = opt.inDir
+            # If tag provided, append it to the output directory.
+            # This is e.g. useful for running different kinds of
+            # reconstruction code on the same input file.
+            if opt.TAG:
+                outDir = opt.inDir.strip("/") + "_" + opt.TAG
+            else:
+                outDir = opt.inDir
         else:
             # create an ouput directory based on relval name
             outDir=opt.RELVAL.replace('/','_')

--- a/SubmitHGCalPGun.py
+++ b/SubmitHGCalPGun.py
@@ -275,11 +275,11 @@ def submitHGCalProduction(*args, **kwargs):
   # prepare dir for GSD outputs locally or at EOS
     if (opt.LOCAL):
         processCmd('mkdir -p '+outDir+'/'+opt.DTIER+'/')
-        recoInputPrefix = 'file:'+currentDir+'/'+outDir+'/'+previousDataTier+'/'
+        recoInputPrefix = 'file:'+currentDir+'/'+opt.inDir+'/'+previousDataTier+'/'
         if (opt.DQM): processCmd('mkdir -p '+outDir+'/DQM/')
     elif opt.eosArea:
         processCmd(eosExec + ' mkdir -p '+opt.eosArea+'/'+outDir+'/'+opt.DTIER+'/');
-        recoInputPrefix = 'root://eoscms.cern.ch/'+opt.eosArea+'/'+outDir+'/'+previousDataTier+'/'
+        recoInputPrefix = 'root://eoscms.cern.ch/'+opt.eosArea+'/'+opt.inDir+'/'+previousDataTier+'/'
         if (opt.DQM): processCmd(eosExec + ' mkdir -p '+opt.eosArea+'/'+outDir+'/DQM/')
     # in case of relval always take reconInput from /store...
     if DASquery: recoInputPrefix=''


### PR DESCRIPTION
The `--tag` option has erroneously been ignored so far for NTUP and RECO steps, preventing the use of output directories different from the input directory (in case of non-RelVal jobs). This PR fixes this and also corrects the README.