### PR TITLE
fix to cutsApplied string

### DIFF
--- a/SubmitHGCalPGun.py
+++ b/SubmitHGCalPGun.py
@@ -312,7 +312,7 @@ def submitHGCalProduction(*args, **kwargs):
     processDetails = '_PDGid'+'_id'.join(sParticle)
     if opt.gunMode == 'physproc':
         processDetails = '_'.join(opt.gunType.split(':'))
-    cutsApplied = '_' + opt.gunType + str(opt.thresholdMin) + 'To' + str(opt.thresholdMax) + '_'
+    cutsApplied = '_'+ '_'.join(opt.gunType.split(':')) + str(opt.thresholdMin) + 'To' + str(opt.thresholdMax) + '_'
     # in case of 'RECO' or 'NTUP', get the input file list for given particle, determine number of jobs, get also basic GSD/RECO info
     if (opt.DTIER == 'RECO' or opt.DTIER == 'NTUP'):
         inputFilesList = getInputFileList(DASquery, inPath, previousDataTier, opt.LOCAL, '*.root')


### PR DESCRIPTION
mimicking the split/join procedure in case the a physproc is being used, otherwise one gets ':' in the file names/submission scripts and jobs fail

@franzoni
