### PR TITLE
options to the produceSkeletons script to enable V11

### DIFF
--- a/SubmitHGCalPGun.py
+++ b/SubmitHGCalPGun.py
@@ -147,8 +147,6 @@ def printSetup(opt, CMSSW_BASE, CMSSW_VERSION, SCRAM_ARCH, currentDir, outDir):
     print 'CMSSW BASE: ', CMSSW_BASE
     print 'CMSSW VER:  ', CMSSW_VERSION,'[', SCRAM_ARCH, ']'
     print 'CONFIGFILE: ', opt.CONFIGFILE
-    if opt.useT3:
-        print '(using the T3 condor group for the submissions)'
     # relval takes precedence...
     if (opt.RELVAL == ''):
         curr_input= opt.inDir
@@ -166,6 +164,8 @@ def printSetup(opt, CMSSW_BASE, CMSSW_VERSION, SCRAM_ARCH, currentDir, outDir):
     print 'OUTPUT DIR: ', outDir
     print 'QUEUE:      ', opt.QUEUE
     print ['NUM. EVTS:   '+str(opt.NEVTS), ''][int(opt.DTIER!='GSD')]
+    if opt.useT3:
+        print 'CONDOR:       using the T3 condor group for the submissions'
     print '--------------------'
 
 ### prepare the list of input GSD files for RECO stage

--- a/SubmitHGCalPGun.py
+++ b/SubmitHGCalPGun.py
@@ -165,7 +165,7 @@ def printSetup(opt, CMSSW_BASE, CMSSW_VERSION, SCRAM_ARCH, currentDir, outDir):
     print 'QUEUE:      ', opt.QUEUE
     print ['NUM. EVTS:   '+str(opt.NEVTS), ''][int(opt.DTIER!='GSD')]
     if opt.useT3:
-        print 'CONDOR:       using the T3 condor group for the submissions'
+        print 'CONDOR:      using the T3 condor group for the submissions'
     print '--------------------'
 
 ### prepare the list of input GSD files for RECO stage

--- a/templates/python/produceSkeletons_D41_NoSmear_PU_AVE_200_BX_25ns_aged.sh
+++ b/templates/python/produceSkeletons_D41_NoSmear_PU_AVE_200_BX_25ns_aged.sh
@@ -38,6 +38,7 @@ action() {
   local geometry="Extended2026D41"
   local pileup_input="das:/RelValMinBias_14TeV/CMSSW_10_6_0_patch2-106X_upgrade2023_realistic_v3_2023D41noPU-v1/GEN-SIM"
   local custom=""
+  local conditions="auto:phase2_realistic"
 
   # parse arguments
   for arg in "$@"; do
@@ -51,6 +52,9 @@ action() {
     elif [[ $arg =~ ^"custom" ]]; then        
         custom=${arg/custom=/}
         echo "Custom options $custom"
+    elif [[ $arg =~ "conditions" ]]; then
+        conditions=${arg/conditions=/}
+        echo "Global tag modified to: $conditions"
     elif [[ $arg =~ ^"pileup_input" ]]; then
         pileup_input=${arg/pileup_input=/}
         #if das is not given try to build the list of files by listing the local directory given
@@ -66,7 +70,7 @@ action() {
   done
 
   cmsDriver.py TTbar_14TeV_TuneCUETP8M1_cfi \
-      --conditions auto:phase2_realistic \
+      --conditions ${conditions} \
       -n 10 \
       --era Phase2C8 \
       --eventcontent FEVTDEBUGHLT \
@@ -82,7 +86,7 @@ action() {
   
 
   cmsDriver.py step3 \
-    --conditions auto:phase2_realistic \
+    --conditions ${conditions} \
     -n 10 \
     --era Phase2C8 \
     --eventcontent FEVTDEBUGHLT,DQM \
@@ -107,7 +111,7 @@ action() {
 
 
   cmsDriver.py step3 \
-    --conditions auto:phase2_realistic \
+    --conditions ${conditions} \
     -n 10 \
     --era Phase2C8 \
     --eventcontent FEVTDEBUGHLT \

--- a/templates/python/produceSkeletons_D41_NoSmear_noPU.sh
+++ b/templates/python/produceSkeletons_D41_NoSmear_noPU.sh
@@ -33,6 +33,9 @@
 action() {
   # default arguments
   local inject_ticl="1"
+  local geometry="Extended2026D41"
+  local custom=""
+  local conditions="auto:phase2_realistic"
 
   # parse arguments
   for arg in "$@"; do
@@ -40,6 +43,15 @@ action() {
       inject_ticl="1"
     elif [ "$arg" = "no-ticl" ]; then
       inject_ticl="0"
+    elif [[ $arg =~ "geometry" ]]; then
+        geometry=${arg/geometry=/}
+        echo "Geometry modified to: $geometry"
+    elif [[ $arg =~ "custom" ]]; then
+        custom=${arg/custom=/}
+        echo "Custom options (full command needed): $custom"
+    elif [[ $arg =~ "conditions" ]]; then
+        conditions=${arg/conditions=/}
+        echo "Global tag modified to: $conditions"
     else
       2>&1 echo "unknown argument: $arg"
       return "1"
@@ -48,27 +60,29 @@ action() {
 
 
   cmsDriver.py SinglePiPt25Eta1p7_2p7_cfi \
-    --conditions auto:phase2_realistic \
+    --conditions ${conditions} \
     -n 10 \
     --era Phase2C8 \
     --eventcontent FEVTDEBUGHLT \
     -s GEN,SIM,DIGI:pdigi_valid,L1,L1TrackTrigger,DIGI2RAW,HLT:@fake2 \
     --datatier GEN-SIM \
     --beamspot NoSmear \
-    --geometry Extended2026D41 \
+      ${custom} \
+    --geometry ${geometry} \
     --no_exec \
     --python_filename=GSD_fragment.py
 
 
   cmsDriver.py step3 \
-    --conditions auto:phase2_realistic \
+    --conditions ${conditions} \
     -n 10 \
     --era Phase2C8 \
     --eventcontent FEVTDEBUGHLT,DQM \
     --runUnscheduled \
     -s RAW2DIGI,L1Reco,RECO,RECOSIM,VALIDATION:@phase2Validation,DQM:@phase2 \
     --datatier GEN-SIM-RECO,DQMIO \
-    --geometry Extended2026D41 \
+      ${custom} \
+    --geometry ${geometry} \
     --no_exec \
     --python_filename=RECO_fragment.py
 
@@ -86,14 +100,15 @@ action() {
 
 
   cmsDriver.py step3 \
-    --conditions auto:phase2_realistic \
+    --conditions ${conditions} \
     -n 10 \
     --era Phase2C8 \
     --eventcontent FEVTDEBUGHLT \
     --runUnscheduled \
     -s RAW2DIGI,L1Reco,RECO,RECOSIM \
     --datatier GEN-SIM-RECO \
-    --geometry Extended2026D41 \
+      ${custom} \
+    --geometry ${geometry} \
     --no_exec \
     --processName=NTUP \
     --python_filename=NTUP_fragment.py


### PR DESCRIPTION
This PR is a minimal approach towards enabling the usage of the V11 geometry for HGCAL MC.

Taking into account @clelange and @rovere 's comments [here](https://github.com/CMS-HGCAL/reco-prodtools/issues/84#issuecomment-540056641),  in this PR I add to produceSkeletons_D41_NoSmear_PU_AVE_200_BX_25ns_aged.sh and produceSkeletons_D41_NoSmear_noPU.sh command line options which allow to specify geometry, custom and global tag.

This is a minimal approach which, together with instructions, will address strictly 

> V11 is not yet fully validated and understood. I'd keep V10 for production with the option to switch to V11 once we are confident.

and can be extended to all produceSkeletons*.sh if desired.

 If we want to add specific scripts like: produceSkeletons_D46_NoSmear_PU_AVE_200_BX_25ns.sh
, where the actual values of geometry, custom and global tag are specified, it can be done as well, following the statement:

>  Thanks - it would just mean adding corresponding shell scripts such as the ones for D41

 - in which case we would need to decide which if the produceSkeletons*.sh would need be duplicated.

@pfs @rovere @clelange 