### PR TITLE
Replace `pointing` option by `nopointing` to remove ambiguity in its meaning

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The processing of TICL iterations is added into the RECO fragment by default. To
 
 Other options like changing the pileup source, calling --customise on cmsDriver or changing geometry can be passed with the following script
 
-```shell 
+```shell
 ./produceSkeletons_D41_NoSmear_PU_AVE_200_BX_25ns_aged.sh \
         pileup_input=/eos/cms//store/group/dpg_hgcal/comm_hgcal/deguio/pu_library/V11/GEN-SIM \
         custom="--customise SLHCUpgradeSimulations/Configuration/aging.agedHGCal" \
@@ -63,7 +63,7 @@ Other options like changing the pileup source, calling --customise on cmsDriver 
 ```
 
 The following script produces the configuration for producing samples with the HFNose sub-detector.
-```shell 
+```shell
 ./produceSkeletons_D44Nose_NoSmear_PU_AVE_200_BX_25ns.sh
 ```
 In order to store HF+Nose hits (and switch off HGCAL hits) in the NTUP step, you need to set the option ```detector = cms.string("HFNose")``` in the ```templates/partGun_NTUP_template.py``` configuration file.
@@ -143,7 +143,7 @@ Another gun that could be used is `--gunMode closeby`, which is capable of creat
 With this choice particles can be produced with random energy, R and Z in a specified range. When more than
 one particle are asked to be produced, then each particle will be created at a different vertex,
 equally spaced by Delta, the arc-distance between two consecutive vertices
-over the circle of radius R. Also, there is the `--pointing` option which if used particles will be produced parallel to the beamline,  otherwise they will be pointing to (0,0,0). Furthermore, there is the `--overlapping` option that if used then
+over the circle of radius R. Also, there is the `--nopointing` option: if used, particles will be produced parallel to the beamline; by default, the particles will be pointing to (0,0,0). Furthermore, there is the `--overlapping` option that if used then
 particles will be generated in a window [phiMin,phiMax], [rMin,rMax], otherwise with a DeltaPhi=Delta/R.
 Another option is `--randomShoot` which if used will shoot a random number of particles. However, this option should be used alongside the `--nRandomPart` in order for the gun to know the upper limit on how many particles to shoot. The `--nRandomPart` option shouldn't be confused with the size of the `--partID` option, since with `--partID` we are setting the particles we are interesting in producing, while with `--nRandomPart` we are randomly choosing the number we want to shoot out of those `--partID` ids.
 Apart from producing multiple particles, this gun could also produce a single particle wherever the user wishes, having always the
@@ -253,7 +253,7 @@ Mind that the `multiClusterTag` option needs to be provided for RECO files creat
 ### ALL steps
 
 Running the 3 steps together in one single submission is possible by specifying the ```--datTier ALL``` option.
-Please note that if this option is activated only the ```NTUP''' is stored in the output directory.  
+Please note that if this option is activated only the ```NTUP''' is stored in the output directory.
 
 ### RelVal
 

--- a/SubmitHGCalPGun.py
+++ b/SubmitHGCalPGun.py
@@ -31,7 +31,7 @@ def createParser():
     parser.add_option('', '--zMax',  dest='zMax',  type=float, default=650.0,    help='max. z value')
     parser.add_option('', '--rMin',  dest='rMin',  type=float, default=0.0,  help='min. r value')
     parser.add_option('', '--rMax',  dest='rMax',  type=float, default=300.0,    help='max. r value')
-    parser.add_option('', '--pointing',  action='store_false',  dest='pointing',  default=True,    help='pointing to (0,0,0) in case of closeby gun')
+    parser.add_option('', '--nopointing',  action='store_false',  dest='pointing',  default=True,    help='produce particles parallel to the beampipe instead of pointing to (0,0,0) in case of closeby gun')
     parser.add_option('', '--overlapping',  action='store_true',  dest='overlapping',  default=False,    help='particles will be generated in window [phiMin,phiMax], [rMin,rMax] (true) or with a DeltaPhi=Delta/R (default false) in case of closeby gun')
     parser.add_option('', '--randomShoot',  action='store_true',  dest='randomShoot',  default=False,    help='if true it will randomly choose one particle in the range [1, NParticles +1 ]')
     parser.add_option('', '--nRandomPart',  dest='NRANDOMPART',  type=int,   default=1,      help='This is used together with randomShoot to shoot randomly [1, NParticles +1 ] particles, default is 1')
@@ -312,12 +312,12 @@ def submitHGCalProduction(*args, **kwargs):
 
         cfgfile = opt.CONFIGFILE
 
-        cfgfile = cfgfile.replace('GSD','RECO')         
+        cfgfile = cfgfile.replace('GSD','RECO')
         fr_template= open(cfgfile, 'r')
         r_template=fr_template.read()
         fr_template.close()
 
-        cfgfile = cfgfile.replace('RECO','NTUP')        
+        cfgfile = cfgfile.replace('RECO','NTUP')
         fn_template= open(cfgfile, 'r')
         n_template=fn_template.read()
         fn_template.close()
@@ -358,7 +358,7 @@ def submitHGCalProduction(*args, **kwargs):
         print 'Submitting job ' + str(job) + ' out of ' + str(njobs) + submittxt
 
         # prepare the out file and cfg file by replacing DUMMY entries according to input options
-        
+
         dtier = opt.DTIER
         if dtier == 'ALL':
             dtier = 'GSD'
@@ -449,22 +449,22 @@ def submitHGCalProduction(*args, **kwargs):
             sn_template=sn_template.replace('DUMMYSGE',str(opt.ADDGENEXTR))
             sn_template=sn_template.replace('DUMMYSPFC',str(opt.storePFCandidates))
             sn_template=sn_template.replace('DUMMYMULCLUSTAG', str(opt.MULTICLUSTAG))
-            
+
 
 
         # submit job
         # now write the file from the s_template
-        
+
         cfgfile_path = outDir + '/cfg/' + cfgfile
         write_template= open(cfgfile_path, 'w')
         write_template.write(s_template)
         write_template.close()
 
-        cfgfiler = 'dummy'      
-        cfgfilen = 'dummy'      
-        
+        cfgfiler = 'dummy'
+        cfgfilen = 'dummy'
+
         if (opt.DTIER == 'ALL'):
-            
+
             cfgfiler = cfgfile.replace('GSD','RECO')
             cfgfiler_path = outDir + '/cfg/' + cfgfiler
             write_template= open(cfgfiler_path, 'w')


### PR DESCRIPTION
By default, the gun is pointing to (0,0,0) and the flag is set to true, so now by calling the flag `--nopointing` and setting the `pointing` bool to false, particles are produced in parallel to the beampipe and there is no ambiguity in its meaning.